### PR TITLE
Pregen fix: exclude custom biome from id mapping

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,8 +9,8 @@
 	<properties>
 		<skip.copy>false</skip.copy>
 		<secretary.build>package</secretary.build>
-		<maven.compiler.source>11</maven.compiler.source>
-		<maven.compiler.target>11</maven.compiler.target>
+		<maven.compiler.source>1.8</maven.compiler.source>
+		<maven.compiler.target>1.8</maven.compiler.target>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 	<build>
@@ -48,9 +48,9 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
-					<compilerVersion>11</compilerVersion>
-					<source>11</source>
-					<target>11</target>
+					<compilerVersion>1.8</compilerVersion>
+					<source>1.8</source>
+					<target>1.8</target>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -9,8 +9,8 @@
 	<properties>
 		<skip.copy>false</skip.copy>
 		<secretary.build>package</secretary.build>
-		<maven.compiler.source>1.8</maven.compiler.source>
-		<maven.compiler.target>1.8</maven.compiler.target>
+		<maven.compiler.source>11</maven.compiler.source>
+		<maven.compiler.target>11</maven.compiler.target>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 	<build>
@@ -48,9 +48,9 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
-					<compilerVersion>1.8</compilerVersion>
-					<source>1.8</source>
-					<target>1.8</target>
+					<compilerVersion>11</compilerVersion>
+					<source>11</source>
+					<target>11</target>
 				</configuration>
 			</plugin>
 		</plugins>
@@ -58,7 +58,7 @@
 	<repositories>
 		<repository>
 			<id>volmit</id>
-			<url>http://repo.volmit.com/repository/volmit/</url>
+			<url>https://repo.volmit.com/repository/volmit/</url>
 		</repository>
 	</repositories>
 	<dependencies>
@@ -71,7 +71,7 @@
 		<dependency>
 			<groupId>org.spigotmc</groupId>
 			<artifactId>spigot-api</artifactId>
-			<version>1.16.1-R0.1-SNAPSHOT</version>
+			<version>1.16.5-R0.1-SNAPSHOT</version>
 			<scope>provided</scope>
 		</dependency>
 		<!-- Paper API -->

--- a/src/main/java/com/volmit/iris/pregen/DirectWorldWriter.java
+++ b/src/main/java/com/volmit/iris/pregen/DirectWorldWriter.java
@@ -240,9 +240,11 @@ public class DirectWorldWriter {
     private static Map<Biome, Integer> computeBiomeIDs() {
         Map<Biome, Integer> biomeIds = new KMap<>();
 
-        for(Biome i : Biome.values())
+        for(Biome biome : Biome.values())
         {
-            biomeIds.put(i, INMS.get().getBiomeId(i));
+            if (biome != Biome.CUSTOM) {
+                biomeIds.put(biome, INMS.get().getBiomeId(biome));
+            }
         }
 
         return biomeIds;

--- a/src/main/java/com/volmit/iris/util/FakeWorld.java
+++ b/src/main/java/com/volmit/iris/util/FakeWorld.java
@@ -17,6 +17,8 @@ import org.bukkit.util.BoundingBox;
 import org.bukkit.util.Consumer;
 import org.bukkit.util.RayTraceResult;
 import org.bukkit.util.Vector;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
 import java.util.*;
@@ -325,10 +327,18 @@ public class FakeWorld implements World
 		return null;
 	}
 
+	@NotNull @Override public Item dropItem(@NotNull Location location, @NotNull ItemStack itemStack, @Nullable Consumer<Item> consumer) {
+		return null;
+	}
+
 	@Override
 	public Item dropItemNaturally(Location location, ItemStack item)
 	{
 
+		return null;
+	}
+
+	@NotNull @Override public Item dropItemNaturally(@NotNull Location location, @NotNull ItemStack itemStack, @Nullable Consumer<Item> consumer) {
 		return null;
 	}
 
@@ -535,6 +545,10 @@ public class FakeWorld implements World
 		return false;
 	}
 
+	@Override public boolean setSpawnLocation(int i, int i1, int i2, float v) {
+		return false;
+	}
+
 	@Override
 	public boolean setSpawnLocation(int x, int y, int z)
 	{
@@ -566,6 +580,10 @@ public class FakeWorld implements World
 	public void setFullTime(long time)
 	{
 
+	}
+
+	@Override public long getGameTime() {
+		return 0;
 	}
 
 	@Override
@@ -618,6 +636,18 @@ public class FakeWorld implements World
 	public void setThunderDuration(int duration)
 	{
 
+	}
+
+	@Override public boolean isClearWeather() {
+		return false;
+	}
+
+	@Override public void setClearWeatherDuration(int i) {
+
+	}
+
+	@Override public int getClearWeatherDuration() {
+		return 0;
 	}
 
 	@Override
@@ -860,6 +890,10 @@ public class FakeWorld implements World
 	public double getHumidity(int x, int y, int z)
 	{
 
+		return 0;
+	}
+
+	@Override public int getMinHeight() {
 		return 0;
 	}
 

--- a/src/main/java/com/volmit/iris/util/HeightedFakeWorld.java
+++ b/src/main/java/com/volmit/iris/util/HeightedFakeWorld.java
@@ -50,6 +50,8 @@ import org.bukkit.util.BoundingBox;
 import org.bukkit.util.Consumer;
 import org.bukkit.util.RayTraceResult;
 import org.bukkit.util.Vector;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 @SuppressWarnings("deprecation")
 public class HeightedFakeWorld implements World
@@ -348,10 +350,18 @@ public class HeightedFakeWorld implements World
 		return null;
 	}
 
+	@NotNull @Override public Item dropItem(@NotNull Location location, @NotNull ItemStack itemStack, @Nullable Consumer<Item> consumer) {
+		return null;
+	}
+
 	@Override
 	public Item dropItemNaturally(Location location, ItemStack item)
 	{
 
+		return null;
+	}
+
+	@NotNull @Override public Item dropItemNaturally(@NotNull Location location, @NotNull ItemStack itemStack, @Nullable Consumer<Item> consumer) {
 		return null;
 	}
 
@@ -558,6 +568,10 @@ public class HeightedFakeWorld implements World
 		return false;
 	}
 
+	@Override public boolean setSpawnLocation(int i, int i1, int i2, float v) {
+		return false;
+	}
+
 	@Override
 	public boolean setSpawnLocation(int x, int y, int z)
 	{
@@ -589,6 +603,10 @@ public class HeightedFakeWorld implements World
 	public void setFullTime(long time)
 	{
 
+	}
+
+	@Override public long getGameTime() {
+		return 0;
 	}
 
 	@Override
@@ -641,6 +659,18 @@ public class HeightedFakeWorld implements World
 	public void setThunderDuration(int duration)
 	{
 
+	}
+
+	@Override public boolean isClearWeather() {
+		return false;
+	}
+
+	@Override public void setClearWeatherDuration(int i) {
+
+	}
+
+	@Override public int getClearWeatherDuration() {
+		return 0;
 	}
 
 	@Override
@@ -883,6 +913,10 @@ public class HeightedFakeWorld implements World
 	public double getHumidity(int x, int y, int z)
 	{
 
+		return 0;
+	}
+
+	@Override public int getMinHeight() {
 		return 0;
 	}
 

--- a/src/main/java/com/volmit/iris/util/MortarSender.java
+++ b/src/main/java/com/volmit/iris/util/MortarSender.java
@@ -1,6 +1,7 @@
 package com.volmit.iris.util;
 
 import java.util.Set;
+import java.util.UUID;
 
 import org.bukkit.Server;
 import org.bukkit.command.CommandSender;
@@ -12,6 +13,8 @@ import org.bukkit.plugin.Plugin;
 
 import lombok.Getter;
 import lombok.Setter;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Represents a volume sender. A command sender with extra crap in it
@@ -191,6 +194,16 @@ public class MortarSender implements CommandSender
 	{
 		for(String str : messages)
 			s.sendMessage(C.translateAlternateColorCodes('&', getTag() + str));
+	}
+
+	@Override
+	public void sendMessage(@Nullable UUID uuid, @NotNull String message) {
+		sendMessage(message);
+	}
+
+	@Override
+	public void sendMessage(@Nullable UUID uuid, @NotNull String[] messages) {
+		sendMessage(messages);
 	}
 
 	@Override


### PR DESCRIPTION
This is a (quick and dirty) fix that enables pregen on the newest purpur builds.

1.16.5 introduced a new biome called "CUSTOM" for which no biome base can be found (NMSBinding16_3:30). This causes an exception when trying to add it to the biome base cache. I excluded this new custom biome from the biome id computation so this problem doesn't occur anymore. I haven't done much research on why this biome base doesn't exist, but we might want to look into what causes it for a better fix in a future release.

For this change I needed to bump the spigot api dependency to version 1.16.5-R0.1 which causes some additional changes in other classes.

This PR also includes further changes in the pom that update the volmit repository url to use HTTPS ~~and bumps the compiler source and target levels to 11.~~ If you don't like these changes I can also roll them back.

I would greatly appreciate any feedback from you guys.