### PR TITLE
fix villager despawning issue

### DIFF
--- a/src/main/java/com/volmit/iris/object/IrisEntity.java
+++ b/src/main/java/com/volmit/iris/object/IrisEntity.java
@@ -263,6 +263,10 @@ public class IrisEntity extends IrisRegistrant
 			((Panda) e).setMainGene(getPandaHiddenGene());
 		}
 
+		if (e instanceof Villager) {
+			((Villager) e).setRemoveWhenFarAway(false);
+		}
+
 		if(Iris.awareEntities && e instanceof Mob)
 		{
 			Mob m = (Mob) e;


### PR DESCRIPTION
This fixes the villager despawning issue.
I have tested it with a purpur server, but I think it will work on all server variants.

To test it you'll need to modify the current overworld package and remove the boat from the villager spawning config.