### PR TITLE
Running EnginePlayer Async  | Fixed DustRevealer was working with normal glowstones

### DIFF
--- a/src/main/java/com/volmit/iris/Iris.java
+++ b/src/main/java/com/volmit/iris/Iris.java
@@ -179,6 +179,7 @@ public class Iris extends VolmitPlugin
 		J.ar(this::checkConfigHotload, 50);
 		PaperLib.suggestPaper(this);
 		getServer().getPluginManager().registerEvents(new CommandLocate(), this);
+		getServer().getPluginManager().registerEvents(new WandManager() ,this);
 		super.onEnable();
 	}
 

--- a/src/main/java/com/volmit/iris/manager/WandManager.java
+++ b/src/main/java/com/volmit/iris/manager/WandManager.java
@@ -319,11 +319,12 @@ public class WandManager implements Listener {
 	public static boolean isWand(Player p)
 	{
 		ItemStack is = p.getInventory().getItemInMainHand();
-		return is != null && is.equals(wand);
+		return is != null && isWand(is);
 	}
 
 	public static boolean isWand(ItemStack is)
 	{
+		ItemStack wand = createWand();
 		if (is.getItemMeta() == null) return false;
 		return is.getType().equals(wand.getType()) &&
 				is.getItemMeta().getDisplayName().equals(wand.getItemMeta().getDisplayName()) &&

--- a/src/main/java/com/volmit/iris/object/IrisEffect.java
+++ b/src/main/java/com/volmit/iris/object/IrisEffect.java
@@ -230,7 +230,7 @@ public class IrisEffect
 		{
 			Location part = p.getLocation().clone().add(RNG.r.i(-soundDistance, soundDistance), RNG.r.i(-soundDistance, soundDistance), RNG.r.i(-soundDistance, soundDistance));
 
-			J.sr(() -> {
+			J.s(() -> {
 				p.playSound(part, getSound(), (float) volume, (float) RNG.r.d(minPitch, maxPitch));
 				Iris.instance.getLogger().info("§bPlayer Location: " +
 						p.getLocation().getBlockX() + " " + p.getLocation().getBlockY() + " " + p.getLocation().getBlockZ() +
@@ -249,7 +249,7 @@ public class IrisEffect
 			part.add(RNG.r.d(), 0, RNG.r.d());
 			if(extra != 0)
 			{
-				J.sr(() -> {
+				J.s(() -> {
 					p.spawnParticle(particleEffect, part.getX(), part.getY() + RNG.r.i(particleOffset),
 						part.getZ(),
 						particleCount,
@@ -262,7 +262,7 @@ public class IrisEffect
 
 			else
 			{
-				J.sr(() -> {
+				J.s(() -> {
 					p.spawnParticle(particleEffect, part.getX(), part.getY() + RNG.r.i(particleOffset), part.getZ(),
 							particleCount,
 							randomAltX ? RNG.r.d(-particleAltX, particleAltX) : particleAltX,
@@ -282,12 +282,12 @@ public class IrisEffect
 					return;
 				}
 
-				J.sr(() -> {
+				J.s(() -> {
 					p.removePotionEffect(getRealType());
 				});
 			}
 
-			J.sr(() -> {
+			J.s(() -> {
 				p.addPotionEffect(new PotionEffect(getRealType(),
 						RNG.r.i(Math.min(potionTicksMax, potionTicksMin),
 								Math.max(potionTicksMax, potionTicksMin)),

--- a/src/main/java/com/volmit/iris/object/IrisEffect.java
+++ b/src/main/java/com/volmit/iris/object/IrisEffect.java
@@ -8,6 +8,7 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.experimental.Accessors;
+import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Particle;
 import org.bukkit.Sound;
@@ -231,7 +232,13 @@ public class IrisEffect
 
 			J.sr(() -> {
 				p.playSound(part, getSound(), (float) volume, (float) RNG.r.d(minPitch, maxPitch));
+				Iris.instance.getLogger().info("§bPlayer Location: " +
+						p.getLocation().getBlockX() + " " + p.getLocation().getBlockY() + " " + p.getLocation().getBlockZ() +
+						"   Sound Location: " + part.getBlockX() + " " + part.getBlockY() + " " + part.getBlockZ() +
+						"   Sound's Name: " + getSound().name());
 			});
+		} else {
+			Bukkit.getConsoleSender().sendMessage("Sound is null :(");
 		}
 
 		if(particleEffect != null)
@@ -275,10 +282,18 @@ public class IrisEffect
 					return;
 				}
 
-				p.removePotionEffect(getRealType());
+				J.sr(() -> {
+					p.removePotionEffect(getRealType());
+				});
 			}
 
-			p.addPotionEffect(new PotionEffect(getRealType(), RNG.r.i(Math.min(potionTicksMax, potionTicksMin), Math.max(potionTicksMax, potionTicksMin)), getPotionStrength(), true, false, false));
+			J.sr(() -> {
+				p.addPotionEffect(new PotionEffect(getRealType(),
+						RNG.r.i(Math.min(potionTicksMax, potionTicksMin),
+								Math.max(potionTicksMax, potionTicksMin)),
+						getPotionStrength(),
+						true, false, false));
+			});
 		}
 	}
 }

--- a/src/main/java/com/volmit/iris/object/IrisEffect.java
+++ b/src/main/java/com/volmit/iris/object/IrisEffect.java
@@ -228,7 +228,10 @@ public class IrisEffect
 		if(sound != null)
 		{
 			Location part = p.getLocation().clone().add(RNG.r.i(-soundDistance, soundDistance), RNG.r.i(-soundDistance, soundDistance), RNG.r.i(-soundDistance, soundDistance));
-			p.playSound(part, getSound(), (float) volume, (float) RNG.r.d(minPitch, maxPitch));
+
+			J.sr(() -> {
+				p.playSound(part, getSound(), (float) volume, (float) RNG.r.d(minPitch, maxPitch));
+			});
 		}
 
 		if(particleEffect != null)
@@ -239,12 +242,26 @@ public class IrisEffect
 			part.add(RNG.r.d(), 0, RNG.r.d());
 			if(extra != 0)
 			{
-				p.spawnParticle(particleEffect, part.getX(), part.getY() + RNG.r.i(particleOffset), part.getZ(), particleCount, randomAltX ? RNG.r.d(-particleAltX, particleAltX) : particleAltX, randomAltY ? RNG.r.d(-particleAltY, particleAltY) : particleAltY, randomAltZ ? RNG.r.d(-particleAltZ, particleAltZ) : particleAltZ, extra);
+				J.sr(() -> {
+					p.spawnParticle(particleEffect, part.getX(), part.getY() + RNG.r.i(particleOffset),
+						part.getZ(),
+						particleCount,
+						randomAltX ? RNG.r.d(-particleAltX, particleAltX) : particleAltX,
+						randomAltY ? RNG.r.d(-particleAltY, particleAltY) : particleAltY,
+						randomAltZ ? RNG.r.d(-particleAltZ, particleAltZ) : particleAltZ,
+						extra);
+				});
 			}
 
 			else
 			{
-				p.spawnParticle(particleEffect, part.getX(), part.getY() + RNG.r.i(particleOffset), part.getZ(), particleCount, randomAltX ? RNG.r.d(-particleAltX, particleAltX) : particleAltX, randomAltY ? RNG.r.d(-particleAltY, particleAltY) : particleAltY, randomAltZ ? RNG.r.d(-particleAltZ, particleAltZ) : particleAltZ);
+				J.sr(() -> {
+					p.spawnParticle(particleEffect, part.getX(), part.getY() + RNG.r.i(particleOffset), part.getZ(),
+							particleCount,
+							randomAltX ? RNG.r.d(-particleAltX, particleAltX) : particleAltX,
+							randomAltY ? RNG.r.d(-particleAltY, particleAltY) : particleAltY,
+							randomAltZ ? RNG.r.d(-particleAltZ, particleAltZ) : particleAltZ);
+				});
 			}
 		}
 

--- a/src/main/java/com/volmit/iris/scaffold/engine/EnginePlayer.java
+++ b/src/main/java/com/volmit/iris/scaffold/engine/EnginePlayer.java
@@ -31,7 +31,7 @@ public class EnginePlayer {
     {
         sample();
 
-        J.s(() -> {
+        J.a(() -> {
             if(region != null)
             {
                 for(IrisEffect j : region.getEffects())

--- a/src/main/java/com/volmit/iris/util/J.java
+++ b/src/main/java/com/volmit/iris/util/J.java
@@ -236,17 +236,6 @@ public class J
 	}
 
 	/**
-	 * Run a sync task
-	 *
-	 * @param r
-	 *            the runnable
-	 */
-	public static void sr(Runnable r)
-	{
-		Bukkit.getScheduler().runTask(Iris.instance, r);
-	}
-
-	/**
 	 * Queue a sync task
 	 *
 	 * @param r

--- a/src/main/java/com/volmit/iris/util/J.java
+++ b/src/main/java/com/volmit/iris/util/J.java
@@ -236,6 +236,17 @@ public class J
 	}
 
 	/**
+	 * Run a sync task
+	 *
+	 * @param r
+	 *            the runnable
+	 */
+	public static void sr(Runnable r)
+	{
+		Bukkit.getScheduler().runTask(Iris.instance, r);
+	}
+
+	/**
 	 * Queue a sync task
 	 *
 	 * @param r


### PR DESCRIPTION
Today I found that normal glowstones will trigger DustRevealer for everyone, I checked out the code and i saw the checks are wrong. There were a isDust method that was checking if the item was a glowstone and not a Dust Revealer custom item.

I also did some small changes, **UNTESTED** but I guess it's fine.
EDIT: I'm testing the changes in my public server, No issues so far.

In this pull request I just wanted to fix the isDust method, Sorry if I broke something

Thanks!