### PR TITLE
Object NBT Support Additions

### DIFF
--- a/src/main/java/com/volmit/iris/object/tile/TileBanner.java
+++ b/src/main/java/com/volmit/iris/object/tile/TileBanner.java
@@ -1,0 +1,116 @@
+package com.volmit.iris.object.tile;
+
+import lombok.Data;
+import net.querz.nbt.tag.CompoundTag;
+import net.querz.nbt.tag.ListTag;
+import org.bukkit.DyeColor;
+import org.bukkit.Material;
+import org.bukkit.block.Banner;
+import org.bukkit.block.banner.Pattern;
+import org.bukkit.block.banner.PatternType;
+import org.bukkit.block.data.BlockData;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+public class TileBanner implements TileData<Banner> {
+    public static final int id = 2;
+
+    private List<Pattern> patterns = new ArrayList<Pattern>();
+    private DyeColor baseColor;
+
+    @Override
+    public String getTileId() {
+        return "minecraft:banner";
+    }
+
+    @Override
+    public boolean isApplicable(BlockData data) {
+        return isBanner(data.getMaterial());
+    }
+
+    @Override
+    public void toBukkit(Banner banner) {
+        banner.setPatterns(patterns);
+        banner.setBaseColor(baseColor);
+    }
+
+    @Override
+    public void fromBukkit(Banner banner) {
+        this.patterns = banner.getPatterns();
+        this.baseColor = banner.getBaseColor();
+    }
+
+    @Override
+    public TileBanner clone() {
+        TileBanner ts = new TileBanner();
+        ts.setBaseColor(getBaseColor());
+        ts.setPatterns(getPatterns());
+        return ts;
+    }
+
+    @Override
+    public void toBinary(DataOutputStream out) throws IOException {
+        out.writeShort(id);
+        out.writeByte(baseColor.ordinal());
+        out.writeByte(patterns.size());
+        for (Pattern p : patterns) {
+            out.writeByte(p.getColor().ordinal());
+            out.writeByte(p.getPattern().ordinal());
+        }
+    }
+
+    @Override
+    public void fromBinary(DataInputStream in) throws IOException {
+        baseColor = DyeColor.values()[in.readByte()];
+        int listSize = in.readByte();
+        patterns = new ArrayList<>();
+
+        for (int i = 0; i < listSize; i++) {
+            DyeColor color = DyeColor.values()[in.readByte()];
+            PatternType type = PatternType.values()[in.readByte()];
+            patterns.add(new Pattern(color, type));
+        }
+    }
+
+    @Override
+    public void toNBT(CompoundTag tag) {
+        ListTag<CompoundTag> listTag = (ListTag<CompoundTag>) ListTag.createUnchecked(CompoundTag.class);
+        for (Pattern p : patterns) {
+            CompoundTag pattern = new CompoundTag();
+            pattern.putString("Pattern", p.getPattern().getIdentifier());
+            pattern.putByte("Color", p.getColor().getDyeData());
+            listTag.add(pattern);
+        }
+        tag.put("Patterns", listTag);
+    }
+
+    public boolean isBanner(Material material) {
+        switch (material) {
+
+            case RED_BANNER:        case RED_WALL_BANNER:
+            case ORANGE_BANNER:     case ORANGE_WALL_BANNER:
+            case YELLOW_BANNER:     case YELLOW_WALL_BANNER:
+            case LIME_BANNER:       case LIME_WALL_BANNER:
+            case GREEN_BANNER:      case GREEN_WALL_BANNER:
+            case CYAN_BANNER:       case CYAN_WALL_BANNER:
+            case LIGHT_BLUE_BANNER: case LIGHT_BLUE_WALL_BANNER:
+            case BLUE_BANNER:       case BLUE_WALL_BANNER:
+            case PURPLE_BANNER:     case PURPLE_WALL_BANNER:
+            case MAGENTA_BANNER:    case MAGENTA_WALL_BANNER:
+            case PINK_BANNER:       case PINK_WALL_BANNER:
+            case WHITE_BANNER:      case WHITE_WALL_BANNER:
+            case LIGHT_GRAY_BANNER: case LIGHT_GRAY_WALL_BANNER:
+            case GRAY_BANNER:       case GRAY_WALL_BANNER:
+            case BLACK_BANNER:      case BLACK_WALL_BANNER:
+            case BROWN_BANNER:      case BROWN_WALL_BANNER:
+                return true;
+            default:
+                return false;
+        }
+    }
+}

--- a/src/main/java/com/volmit/iris/object/tile/TileData.java
+++ b/src/main/java/com/volmit/iris/object/tile/TileData.java
@@ -12,7 +12,7 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 
 public interface TileData<T extends TileState> extends Cloneable {
-    public static int id = 0;
+
     public static final KList<TileData<? extends TileState>> registry = setup();
 
     static KList<TileData<? extends TileState>> setup() {
@@ -20,6 +20,7 @@ public interface TileData<T extends TileState> extends Cloneable {
 
         registry.add(new TileSign());
         registry.add(new TileSpawner());
+        registry.add(new TileBanner());
 
         return registry;
     }

--- a/src/main/java/com/volmit/iris/object/tile/TileSign.java
+++ b/src/main/java/com/volmit/iris/object/tile/TileSign.java
@@ -13,7 +13,7 @@ import java.io.IOException;
 
 @Data
 public class TileSign implements TileData<Sign> {
-    public static int id = TileData.id;
+    public static final int id = 0;
     private String line1;
     private String line2;
     private String line3;

--- a/src/main/java/com/volmit/iris/object/tile/TileSpawner.java
+++ b/src/main/java/com/volmit/iris/object/tile/TileSpawner.java
@@ -3,9 +3,9 @@ package com.volmit.iris.object.tile;
 import lombok.Data;
 import net.querz.nbt.tag.CompoundTag;
 import net.querz.nbt.tag.ListTag;
+import org.bukkit.Material;
 import org.bukkit.block.CreatureSpawner;
 import org.bukkit.block.data.BlockData;
-import org.bukkit.block.data.type.WallSign;
 import org.bukkit.entity.EntityType;
 
 import java.io.DataInputStream;
@@ -14,7 +14,7 @@ import java.io.IOException;
 
 @Data
 public class TileSpawner implements TileData<CreatureSpawner> {
-    public static int id = TileData.id;
+    public static final int id = 1;
     private EntityType entityType;
 
     @Override
@@ -24,7 +24,7 @@ public class TileSpawner implements TileData<CreatureSpawner> {
 
     @Override
     public boolean isApplicable(BlockData data) {
-        return data instanceof org.bukkit.block.data.type.Sign || data instanceof WallSign;
+        return data.getMaterial() == Material.SPAWNER;
     }
 
     @Override


### PR DESCRIPTION
- Added support for banner NBT to be saved to objects
- Fixed spawners not saving their spawn type to objects
- Removed pointless IDs from the TileEntity registry system

All tested and both spawners and banners work fine