### PR TITLE
Fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group 'com.volmit.iris'
-version '1.3.10'
+version '1.4'
 def apiVersion = '1.14'
 def name = 'Iris'
 def main = 'com.volmit.iris.Iris'
@@ -57,9 +57,10 @@ def registerCustomOutputTask(name, path) {
 
 
 dependencies {
-    compileOnly 'org.projectlombok:lombok:1.18.12'
-    annotationProcessor 'org.projectlombok:lombok:1.18.12'
-    implementation 'io.timeandspace:smoothie-map:2.0.2'
+    compileOnly 'org.projectlombok:lombok:1.18.20'
+    annotationProcessor 'org.projectlombok:lombok:1.18.20'
+
+    // Shade
     implementation 'com.github.ben-manes.caffeine:caffeine:2.8.5'
     implementation 'org.zeroturnaround:zt-zip:1.14'
     implementation 'io.papermc:paperlib:1.0.5'

--- a/src/main/java/com/volmit/iris/manager/command/jigsaw/CommandIrisJigsawEdit.java
+++ b/src/main/java/com/volmit/iris/manager/command/jigsaw/CommandIrisJigsawEdit.java
@@ -53,7 +53,10 @@ public class CommandIrisJigsawEdit extends MortarCommand
 		{
 			File dest = piece.getLoadFile();
 			new JigsawEditor(sender.player(), piece, IrisDataManager.loadAnyObject(piece.getObject()), dest);
+			return true;
 		}
+
+		sender.sendMessage("Failed to find existing jigsaw piece: " + args[0]);
 
 		return true;
 	}

--- a/src/main/java/com/volmit/iris/manager/command/jigsaw/CommandIrisJigsawNew.java
+++ b/src/main/java/com/volmit/iris/manager/command/jigsaw/CommandIrisJigsawNew.java
@@ -48,6 +48,12 @@ public class CommandIrisJigsawNew extends MortarCommand
 		}
 
 		IrisObject object = IrisDataManager.loadAnyObject(args[2]);
+
+		if (object == null) {
+			sender.sendMessage("Failed to find existing object: " + args[2]);
+			return true;
+		}
+
 		File dest = Iris.instance.getDataFile("packs", args[1], "jigsaw-pieces", args[0] + ".json");
 		new JigsawEditor(sender.player(), null, object, dest);
 		sender.sendMessage("* Right Click blocks to make them connectors");

--- a/src/main/java/com/volmit/iris/manager/command/studio/CommandIrisStudio.java
+++ b/src/main/java/com/volmit/iris/manager/command/studio/CommandIrisStudio.java
@@ -43,6 +43,9 @@ public class CommandIrisStudio extends MortarCommand
 	private CommandIrisStudioExplorer exp;
 
 	@Command
+	private CommandIrisStudioExplorerGenerator generator;
+
+	@Command
 	private CommandIrisStudioLoot loot;
 
 	@Command

--- a/src/main/java/com/volmit/iris/manager/command/studio/CommandIrisStudioExplorerGenerator.java
+++ b/src/main/java/com/volmit/iris/manager/command/studio/CommandIrisStudioExplorerGenerator.java
@@ -40,6 +40,12 @@ public class CommandIrisStudioExplorerGenerator extends MortarCommand
 			return true;
 		}
 
+		if (args.length == 0)
+		{
+			sender.sendMessage("Specify a generator to preview");
+			return true;
+		}
+
 		IrisGenerator generator;
 		long seed = 12345;
 

--- a/src/main/java/com/volmit/iris/object/IrisEntityInitialSpawn.java
+++ b/src/main/java/com/volmit/iris/object/IrisEntityInitialSpawn.java
@@ -80,6 +80,6 @@ public class IrisEntityInitialSpawn
 
 	private Entity spawn100(Engine g, Location at)
 	{
-		return getRealEntity(g).spawn(g, at.clone().add(0, 1, 0), rng.aquire(() -> new RNG(g.getTarget().getWorld().getSeed() + 4)));
+		return getRealEntity(g).spawn(g, at.clone().add(0.5, 1, 0.5), rng.aquire(() -> new RNG(g.getTarget().getWorld().getSeed() + 4)));
 	}
 }

--- a/src/main/java/com/volmit/iris/object/IrisObject.java
+++ b/src/main/java/com/volmit/iris/object/IrisObject.java
@@ -5,8 +5,6 @@ import com.volmit.iris.manager.IrisDataManager;
 import com.volmit.iris.object.tile.TileData;
 import com.volmit.iris.scaffold.cache.AtomicCache;
 import com.volmit.iris.util.*;
-import io.timeandspace.smoothie.OptimizationObjective;
-import io.timeandspace.smoothie.SmoothieMap;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.experimental.Accessors;
@@ -34,8 +32,8 @@ public class IrisObject extends IrisRegistrant
 	private static final BlockData VAIR_DEBUG = B.get("COBWEB");
 	private static final BlockData[] SNOW_LAYERS = new BlockData[] {B.get("minecraft:snow[layers=1]"), B.get("minecraft:snow[layers=2]"), B.get("minecraft:snow[layers=3]"), B.get("minecraft:snow[layers=4]"), B.get("minecraft:snow[layers=5]"), B.get("minecraft:snow[layers=6]"), B.get("minecraft:snow[layers=7]"), B.get("minecraft:snow[layers=8]")};
 	public static boolean shitty = false;
-	private SmoothieMap<BlockVector, BlockData> blocks;
-	private SmoothieMap<BlockVector, TileData<? extends TileState>> states;
+	private KMap<BlockVector, BlockData> blocks;
+	private KMap<BlockVector, TileData<? extends TileState>> states;
 	private int w;
 	private int d;
 	private int h;
@@ -219,15 +217,8 @@ public class IrisObject extends IrisRegistrant
 	public IrisObject(int w, int h, int d)
 	{
 		Iris.warnsmoothie();
-		blocks = SmoothieMap.<BlockVector, BlockData>newBuilder()
-				.doShrink(true)
-				.optimizeFor(OptimizationObjective.LOW_GARBAGE)
-				.expectedSize(Math.max(100, (w * h * d) / 2))
-				.build();
-		states = SmoothieMap.<BlockVector, TileData<? extends TileState>>newBuilder()
-				.doShrink(true)
-				.optimizeFor(OptimizationObjective.LOW_GARBAGE)
-				.build();
+		blocks = new KMap<>();
+		states = new KMap<>();
 		this.w = w;
 		this.h = h;
 		this.d = d;
@@ -383,22 +374,14 @@ public class IrisObject extends IrisRegistrant
 
 	public void clean()
 	{
-		SmoothieMap<BlockVector, BlockData> d = SmoothieMap.<BlockVector, BlockData>newBuilder()
-				.doShrink(true)
-				.optimizeFor(OptimizationObjective.LOW_GARBAGE)
-				.expectedSize(getBlocks().size())
-				.build();
+		KMap<BlockVector, BlockData> d = new KMap<>();
 
 		for(BlockVector i : getBlocks().keySet())
 		{
 			d.put(new BlockVector(i.getBlockX(), i.getBlockY(), i.getBlockZ()), Objects.requireNonNull(getBlocks().get(i)));
 		}
 
-		SmoothieMap<BlockVector, TileData<? extends TileState>> dx = SmoothieMap.<BlockVector, TileData<? extends TileState>>newBuilder()
-				.doShrink(true)
-				.optimizeFor(OptimizationObjective.LOW_GARBAGE)
-				.expectedSize(getStates().size())
-				.build();
+		KMap<BlockVector, TileData<? extends TileState>> dx = new KMap<>();
 
 		for(BlockVector i : getBlocks().keySet())
 		{
@@ -842,22 +825,14 @@ public class IrisObject extends IrisRegistrant
 
 	public void rotate(IrisObjectRotation r, int spinx, int spiny, int spinz)
 	{
-		SmoothieMap<BlockVector, BlockData> d = SmoothieMap.<BlockVector, BlockData>newBuilder()
-				.doShrink(true)
-				.optimizeFor(OptimizationObjective.LOW_GARBAGE)
-				.expectedSize(getBlocks().size())
-				.build();
+		KMap<BlockVector, BlockData> d = new KMap<>();
 
 		for(BlockVector i : getBlocks().keySet())
 		{
 			d.put(r.rotate(i.clone(), spinx, spiny, spinz), r.rotate(Objects.requireNonNull(getBlocks().get(i)).clone(), spinx, spiny, spinz));
 		}
 
-		SmoothieMap<BlockVector, TileData<? extends TileState>> dx = SmoothieMap.<BlockVector, TileData<? extends TileState>>newBuilder()
-				.doShrink(true)
-				.optimizeFor(OptimizationObjective.LOW_GARBAGE)
-				.expectedSize(getStates().size())
-				.build();
+		KMap<BlockVector, TileData<? extends TileState>> dx = new KMap<>();
 
 		for(BlockVector i : getStates().keySet())
 		{
@@ -899,12 +874,12 @@ public class IrisObject extends IrisRegistrant
 		}
 	}
 
-	public synchronized SmoothieMap<BlockVector, BlockData> getBlocks()
+	public synchronized KMap<BlockVector, BlockData> getBlocks()
 	{
 		return blocks;
 	}
 
-	public synchronized SmoothieMap<BlockVector, TileData<? extends TileState>> getStates()
+	public synchronized KMap<BlockVector, TileData<? extends TileState>> getStates()
 	{
 		return states;
 	}

--- a/src/main/java/com/volmit/iris/object/IrisObjectRotation.java
+++ b/src/main/java/com/volmit/iris/object/IrisObjectRotation.java
@@ -243,7 +243,9 @@ public class IrisObjectRotation
 			BlockVector bv = new BlockVector(f.getModX(), f.getModY(), f.getModZ());
 			bv = rotate(bv.clone(), spinx, spiny, spinz);
 			BlockFace t = getFace(bv);
-			g.setRotation(t);
+			if (t.getModY() == 0) {
+				g.setRotation(t);
+			}
 		}
 
 		else if(d instanceof Orientable)

--- a/src/main/java/com/volmit/iris/object/IrisObjectRotation.java
+++ b/src/main/java/com/volmit/iris/object/IrisObjectRotation.java
@@ -155,6 +155,42 @@ public class IrisObjectRotation
 		return BlockFace.SOUTH;
 	}
 
+	public BlockFace getHexFace(BlockVector v)
+	{
+		int x = v.getBlockX();
+		int y = v.getBlockY();
+		int z = v.getBlockZ();
+
+		if(x == 0 && z == -1) return BlockFace.NORTH;
+		if(x == 1 && z == -2) return BlockFace.NORTH_NORTH_EAST;
+		if(x == 1 && z == -1) return BlockFace.NORTH_EAST;
+		if(x == 2 && z == -1) return BlockFace.EAST_NORTH_EAST;
+		if(x == 1 && z == 0) return BlockFace.EAST;
+		if(x == 2 && z == 1) return BlockFace.EAST_SOUTH_EAST;
+		if(x == 1 && z == 1) return BlockFace.SOUTH_EAST;
+		if(x == 1 && z == 2) return BlockFace.SOUTH_SOUTH_EAST;
+		if(x == 0 && z == 1) return BlockFace.SOUTH;
+		if(x == -1 && z == 2) return BlockFace.SOUTH_SOUTH_WEST;
+		if(x == -1 && z == 1) return BlockFace.SOUTH_WEST;
+		if(x == -2 && z == 1) return BlockFace.WEST_SOUTH_WEST;
+		if(x == -1 && z == 0) return BlockFace.WEST;
+		if(x == -2 && z == -1) return BlockFace.WEST_NORTH_WEST;
+		if(x == -1 && z == -1) return BlockFace.NORTH_WEST;
+		if(x == -1 && z == -2) return BlockFace.NORTH_NORTH_WEST;
+
+		if(y > 0)
+		{
+			return BlockFace.UP;
+		}
+
+		if(y < 0)
+		{
+			return BlockFace.DOWN;
+		}
+
+		return BlockFace.SOUTH;
+	}
+
 	public BlockFace faceForAxis(Axis axis)
 	{
 		switch(axis)
@@ -240,12 +276,13 @@ public class IrisObjectRotation
 		{
 			Rotatable g = ((Rotatable) d);
 			BlockFace f = g.getRotation();
-			BlockVector bv = new BlockVector(f.getModX(), f.getModY(), f.getModZ());
+
+			BlockVector bv = new BlockVector(f.getModX(), 0, f.getModZ());
 			bv = rotate(bv.clone(), spinx, spiny, spinz);
-			BlockFace t = getFace(bv);
-			if (t.getModY() == 0) {
-				g.setRotation(t);
-			}
+			BlockFace face = getHexFace(bv);
+
+			g.setRotation(face);
+
 		}
 
 		else if(d instanceof Orientable)

--- a/src/main/java/com/volmit/iris/scaffold/jigsaw/PlannedPiece.java
+++ b/src/main/java/com/volmit/iris/scaffold/jigsaw/PlannedPiece.java
@@ -9,6 +9,7 @@ import com.volmit.iris.util.KList;
 import com.volmit.iris.util.RNG;
 import lombok.Data;
 import org.bukkit.World;
+import org.bukkit.block.BlockState;
 import org.bukkit.block.TileState;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.util.BlockVector;
@@ -163,7 +164,7 @@ public class PlannedPiece {
 
             @Override
             public boolean isSolid(int x, int y, int z) {
-                return false;
+                return world.getBlockAt(x,y,z).getType().isSolid();
             }
 
             @Override
@@ -183,7 +184,9 @@ public class PlannedPiece {
 
             @Override
             public void setTile(int xx, int yy, int zz, TileData<? extends TileState> tile) {
-
+                BlockState state = world.getBlockAt(xx,yy,zz).getState();
+                tile.toBukkitTry(state);
+                state.update();
             }
         }, piece.getPlacementOptions(), new RNG(), getData());
     }

--- a/src/main/java/com/volmit/iris/scaffold/jigsaw/PlannedPiece.java
+++ b/src/main/java/com/volmit/iris/scaffold/jigsaw/PlannedPiece.java
@@ -21,7 +21,7 @@ public class PlannedPiece {
     private IrisJigsawPiece piece;
     private IrisObjectRotation rotation;
     private IrisDataManager data;
-    private KList<IrisPosition> connected;
+    private KList<IrisJigsawPieceConnector> connected;
     private boolean dead = false;
     private int rotationKey;
     private AxisAlignedBB box;
@@ -95,7 +95,7 @@ public class PlannedPiece {
 
         for(IrisJigsawPieceConnector i : piece.getConnectors())
         {
-            if(!connected.contains(i.getPosition()))
+            if(!connected.contains(i))
             {
                 c.add(i);
             }
@@ -108,15 +108,10 @@ public class PlannedPiece {
     {
         if(piece.getConnectors().contains(c))
         {
-            return connect(c.getPosition());
+            return connected.addIfMissing(c);
         }
 
         return false;
-    }
-
-    private boolean connect(IrisPosition p)
-    {
-        return connected.addIfMissing(p);
     }
 
     public IrisPosition getWorldPosition(IrisJigsawPieceConnector c)

--- a/src/main/java/com/volmit/iris/scaffold/jigsaw/PlannedStructure.java
+++ b/src/main/java/com/volmit/iris/scaffold/jigsaw/PlannedStructure.java
@@ -179,7 +179,7 @@ public class PlannedStructure {
     }
 
     private void generateOutwards() {
-        for(PlannedPiece i : getPiecesWithAvailableConnectors().shuffleCopy(rng))
+        for(PlannedPiece i : getPiecesWithAvailableConnectors().shuffle(rng))
         {
             if(!generatePieceOutwards(i))
             {
@@ -317,7 +317,7 @@ public class PlannedStructure {
             {
                 IrisJigsawPiece pi = getData().getJigsawPieceLoader().load(j);
 
-                if(terminating && !pi.isTerminal())
+                if (pi == null || (terminating && !pi.isTerminal()))
                 {
                     continue;
                 }
@@ -325,8 +325,7 @@ public class PlannedStructure {
                 p.addIfMissing(pi);
             }
         }
-
-        return p.shuffleCopy(rng);
+        return p.shuffle(rng);
     }
 
     private void generateStartPiece() {

--- a/src/main/java/net/querz/mca/Section.java
+++ b/src/main/java/net/querz/mca/Section.java
@@ -1,8 +1,7 @@
 package net.querz.mca;
 
 import com.volmit.iris.Iris;
-import io.timeandspace.smoothie.OptimizationObjective;
-import io.timeandspace.smoothie.SmoothieMap;
+import com.volmit.iris.util.KMap;
 import net.querz.nbt.tag.ByteArrayTag;
 import net.querz.nbt.tag.CompoundTag;
 import net.querz.nbt.tag.ListTag;
@@ -18,8 +17,7 @@ import static net.querz.mca.LoadFlags.*;
 public class Section {
 
 	private CompoundTag data;
-	private Map<String, List<PaletteIndex>> valueIndexedPalette = SmoothieMap.<String, List<PaletteIndex>>newBuilder()
-			.optimizeFor(OptimizationObjective.FOOTPRINT).build();
+	private Map<String, List<PaletteIndex>> valueIndexedPalette = new KMap<>();
 	private ListTag<CompoundTag> palette;
 	private byte[] blockLight;
 	private long[] blockStates;

--- a/src/main/java/net/querz/nbt/tag/CompoundTag.java
+++ b/src/main/java/net/querz/nbt/tag/CompoundTag.java
@@ -1,8 +1,7 @@
 package net.querz.nbt.tag;
 
 import com.volmit.iris.Iris;
-import io.timeandspace.smoothie.OptimizationObjective;
-import io.timeandspace.smoothie.SmoothieMap;
+import com.volmit.iris.util.KMap;
 import net.querz.io.MaxDepthIO;
 
 import java.util.*;
@@ -23,8 +22,7 @@ public class CompoundTag extends Tag<Map<String, Tag<?>>> implements Iterable<Ma
 	}
 
 	private static Map<String, Tag<?>> createEmptyValue() {
-		return SmoothieMap.<String, Tag<?>>newBuilder()
-				.optimizeFor(OptimizationObjective.FOOTPRINT).build();
+		return new KMap<>();
 	}
 
 	public int size() {


### PR DESCRIPTION
- Fixed NPE occuring when Jigsaw fails to find Object in pool. Now just produces a warning in the console like it should
- Fixed pointless copies of lists being created within PlannedStructure
- Fixed mobs spawning within other blocks and suffocating on spawn
- Fixed creating a jigsaw with a non existent object causing jigsaw commands to lock up (#377)
- Fixed editing a non existent jigsaw just not doing anything
---
- Fixed Jigsaws not placing TileStates
- Fixed NPE when banners, signs or skulls try to be rotated to be up or down
---
- Fixed double sided connectors not working properly
- Fixed skulls not being able to be rotated when they are placed on an angle that isn't perfectly straight (north, south, east, west)