### PR TITLE
Fixed Strongholds not generating in 1.17

### DIFF
--- a/src/main/java/com/volmit/iris/object/IrisPosition.java
+++ b/src/main/java/com/volmit/iris/object/IrisPosition.java
@@ -57,4 +57,9 @@ public class IrisPosition
     public IrisPosition copy() {
 		return new IrisPosition(x,y,z);
     }
+
+    @Override
+    public String toString() {
+		return "[" + getX() + "," + getY() + "," + getZ() + "]";
+	}
 }


### PR DESCRIPTION
- Fixed Strongholds not generating in 1.17
- Made 9 strongholds now generate by default

Dev note: Tile entities are not placing correctly in jigsaws when generating (manual placement is fine)