### PR TITLE
Decorator Updates

### DIFF
--- a/src/main/java/com/volmit/iris/generator/IrisComplex.java
+++ b/src/main/java/com/volmit/iris/generator/IrisComplex.java
@@ -52,6 +52,7 @@ public class IrisComplex implements DataProvider
 	private ProceduralStream<IrisDecorator> terrainCaveSurfaceDecoration;
 	private ProceduralStream<IrisDecorator> terrainCaveCeilingDecoration;
 	private ProceduralStream<IrisDecorator> seaSurfaceDecoration;
+	private ProceduralStream<IrisDecorator> seaFloorDecoration;
 	private ProceduralStream<IrisDecorator> shoreSurfaceDecoration;
 	private ProceduralStream<BlockData> rockStream;
 	private ProceduralStream<BlockData> fluidStream;
@@ -191,6 +192,8 @@ public class IrisComplex implements DataProvider
 			.convertAware2D((b, xx,zz) -> decorateFor(b, xx, zz, DecorationPart.SHORE_LINE));
 		seaSurfaceDecoration = trueBiomeStream
 			.convertAware2D((b, xx,zz) -> decorateFor(b, xx, zz, DecorationPart.SEA_SURFACE));
+		seaFloorDecoration = trueBiomeStream
+				.convertAware2D((b, xx,zz) -> decorateFor(b, xx, zz, DecorationPart.SEA_FLOOR));
 		trueHeightStream = ProceduralStream.of((x, z) -> {
 			int rx = (int) Math.round(engine.modifyX(x));
 			int rz = (int) Math.round(engine.modifyZ(z));

--- a/src/main/java/com/volmit/iris/generator/actuator/IrisDecorantActuator.java
+++ b/src/main/java/com/volmit/iris/generator/actuator/IrisDecorantActuator.java
@@ -106,7 +106,7 @@ public class IrisDecorantActuator extends EngineAssignedActuator<BlockData>
                         {
                             if (emptyFor > 0) {
                                 getSurfaceDecorator().decorate(i, j, realX, realZ, output, cave, k, emptyFor);
-                                getCeilingDecorator().decorate(i, j, realX, realZ, output, cave, lastSolid, emptyFor);
+                                getCeilingDecorator().decorate(i, j, realX, realZ, output, cave, lastSolid - 1, emptyFor);
                                 emptyFor = 0;
                             }
                             lastSolid = k;

--- a/src/main/java/com/volmit/iris/generator/actuator/IrisDecorantActuator.java
+++ b/src/main/java/com/volmit/iris/generator/actuator/IrisDecorantActuator.java
@@ -1,5 +1,6 @@
 package com.volmit.iris.generator.actuator;
 
+import com.volmit.iris.generator.decorator.IrisSeaFloorDecorator;
 import com.volmit.iris.object.IrisBiome;
 import com.volmit.iris.util.PrecisionStopwatch;
 import com.volmit.iris.util.RNG;
@@ -28,6 +29,8 @@ public class IrisDecorantActuator extends EngineAssignedActuator<BlockData>
     @Getter
     private final EngineDecorator seaSurfaceDecorator;
     @Getter
+    private final EngineDecorator seaFloorDecorator;
+    @Getter
     private final EngineDecorator shoreLineDecorator;
     private final boolean shouldRay;
 
@@ -39,6 +42,7 @@ public class IrisDecorantActuator extends EngineAssignedActuator<BlockData>
         ceilingDecorator = new IrisCeilingDecorator(getEngine());
         seaSurfaceDecorator = new IrisSeaSurfaceDecorator(getEngine());
         shoreLineDecorator = new IrisShoreLineDecorator(getEngine());
+        seaFloorDecorator = new IrisSeaFloorDecorator(getEngine());
     }
 
     @Override
@@ -49,9 +53,7 @@ public class IrisDecorantActuator extends EngineAssignedActuator<BlockData>
         }
 
         PrecisionStopwatch p = PrecisionStopwatch.start();
-        boolean solid;
-        int emptyFor = 0;
-        int lastSolid = 0;
+
         int j, realX, realZ, height;
         IrisBiome biome, cave;
 
@@ -59,6 +61,9 @@ public class IrisDecorantActuator extends EngineAssignedActuator<BlockData>
         {
             for(j = 0; j < output.getDepth(); j++)
             {
+                boolean solid;
+                int emptyFor = 0;
+                int lastSolid = 0;
                 realX = (int) Math.round(modX(x + i));
                 realZ = (int) Math.round(modZ(z + j));
                 height = (int) Math.round(getComplex().getHeightStream().get(realX, realZ));
@@ -77,10 +82,16 @@ public class IrisDecorantActuator extends EngineAssignedActuator<BlockData>
                             realZ, (int) Math.round(modZ(z + j+1)), (int) Math.round(modZ(z + j-1)),
                             output, biome, height, getEngine().getHeight() - height);
                 }
-
+                else if (height == getDimension().getFluidHeight() + 1)
+                {
+                    getSeaSurfaceDecorator().decorate(i, j,
+                            realX, (int) Math.round(modX(x + i+1)), (int) Math.round(modX(x + i-1)),
+                            realZ, (int) Math.round(modZ(z + j+1)), (int) Math.round(modZ(z + j-1)),
+                            output, biome, height, getEngine().getHeight() - getDimension().getFluidHeight());
+                }
                 else if(height < getDimension().getFluidHeight())
                 {
-                    getSeaSurfaceDecorator().decorate(i, j, realX, realZ, output, biome, getDimension().getFluidHeight(), getEngine().getHeight() - getDimension().getFluidHeight());
+                    getSeaFloorDecorator().decorate(i, j, realX, realZ, output, biome, height + 1, getDimension().getFluidHeight());
                 }
 
                 getSurfaceDecorator().decorate(i, j, realX, realZ, output, biome, height, getEngine().getHeight() - height);
@@ -93,18 +104,16 @@ public class IrisDecorantActuator extends EngineAssignedActuator<BlockData>
 
                         if(solid)
                         {
+                            if (emptyFor > 0) {
+                                getSurfaceDecorator().decorate(i, j, realX, realZ, output, cave, k, emptyFor);
+                                getCeilingDecorator().decorate(i, j, realX, realZ, output, cave, lastSolid, emptyFor);
+                                emptyFor = 0;
+                            }
                             lastSolid = k;
                         }
-
-                        else {
-                            emptyFor++;
-                        }
-
-                        if(solid && emptyFor > 0)
+                        else
                         {
-                            getCeilingDecorator().decorate(i, j, realX, realZ, output, cave, lastSolid, emptyFor);
-                            getSurfaceDecorator().decorate(i, j, realX, realZ, output, cave, k, emptyFor);
-                            emptyFor = 0;
+                            emptyFor++;
                         }
                     }
                 }

--- a/src/main/java/com/volmit/iris/generator/decorator/IrisCeilingDecorator.java
+++ b/src/main/java/com/volmit/iris/generator/decorator/IrisCeilingDecorator.java
@@ -22,16 +22,17 @@ public class IrisCeilingDecorator extends IrisEngineDecorator
         {
             if(!decorator.isStacking())
             {
-                data.set(x, height-1, z, decorator.getBlockData100(biome, getRng(), realX, realZ, getData()));
+                data.set(x, height, z, decorator.getBlockData100(biome, getRng(), realX, realZ, getData()));
             }
 
             else
             {
-                int stack = Math.min(getRng().nextParallelRNG(Cache.key(realX, realZ)).i(decorator.getStackMin(), decorator.getStackMax()), max);
+                int stack = decorator.getHeight(getRng().nextParallelRNG(Cache.key(realX, realZ)), realX, realZ, getData());
+                stack = Math.min(max + 1, stack);
 
                 for(int i = 0; i < stack; i++)
                 {
-                    data.set(x, height-1-i, z, i == stack-1 ? decorator.getBlockDataForTop(biome, getRng(), realX+i, realZ-i, getData()) : decorator.getBlockData100(biome, getRng(), realX+i, realZ-i, getData()));
+                    data.set(x, height-i, z, i == 0 ? decorator.getBlockDataForTop(biome, getRng(), realX, realZ, getData()) : decorator.getBlockData100(biome, getRng(), realX, realZ, getData()));
                 }
             }
         }

--- a/src/main/java/com/volmit/iris/generator/decorator/IrisCeilingDecorator.java
+++ b/src/main/java/com/volmit/iris/generator/decorator/IrisCeilingDecorator.java
@@ -30,9 +30,13 @@ public class IrisCeilingDecorator extends IrisEngineDecorator
                 int stack = decorator.getHeight(getRng().nextParallelRNG(Cache.key(realX, realZ)), realX, realZ, getData());
                 stack = Math.min(max + 1, stack);
 
+                BlockData top = decorator.getBlockDataForTop(biome, getRng(), realX, realZ, getData());
+                BlockData fill = decorator.getBlockData100(biome, getRng(), realX, realZ, getData());
+
                 for(int i = 0; i < stack; i++)
                 {
-                    data.set(x, height-i, z, i == 0 ? decorator.getBlockDataForTop(biome, getRng(), realX, realZ, getData()) : decorator.getBlockData100(biome, getRng(), realX, realZ, getData()));
+                    double threshold = (((double)i) / (double)(stack - 1));
+                    data.set(x, height-i, z, threshold >= decorator.getTopThreshold() ? top : fill);
                 }
             }
         }

--- a/src/main/java/com/volmit/iris/generator/decorator/IrisCeilingDecorator.java
+++ b/src/main/java/com/volmit/iris/generator/decorator/IrisCeilingDecorator.java
@@ -36,7 +36,7 @@ public class IrisCeilingDecorator extends IrisEngineDecorator
                 for(int i = 0; i < stack; i++)
                 {
                     double threshold = (((double)i) / (double)(stack - 1));
-                    data.set(x, height-i, z, threshold >= decorator.getTopThreshold() ? top : fill);
+                    data.set(x, height - i, z, threshold >= decorator.getTopThreshold() ? top : fill);
                 }
             }
         }

--- a/src/main/java/com/volmit/iris/generator/decorator/IrisSeaFloorDecorator.java
+++ b/src/main/java/com/volmit/iris/generator/decorator/IrisSeaFloorDecorator.java
@@ -1,0 +1,45 @@
+package com.volmit.iris.generator.decorator;
+
+import com.volmit.iris.Iris;
+import com.volmit.iris.object.DecorationPart;
+import com.volmit.iris.object.IrisBiome;
+import com.volmit.iris.object.IrisDecorator;
+import com.volmit.iris.scaffold.cache.Cache;
+import com.volmit.iris.scaffold.engine.Engine;
+import com.volmit.iris.scaffold.hunk.Hunk;
+import org.bukkit.block.data.BlockData;
+
+public class IrisSeaFloorDecorator extends IrisEngineDecorator
+{
+    public IrisSeaFloorDecorator(Engine engine) {
+        super(engine, "Sea Floor", DecorationPart.SEA_FLOOR);
+    }
+
+    @Override
+    public void decorate(int x, int z, int realX, int realX1, int realX_1, int realZ, int realZ1, int realZ_1, Hunk<BlockData> data, IrisBiome biome, int height, int max) {
+        if(height <= getDimension().getFluidHeight()) {
+
+            IrisDecorator decorator = getDecorator(biome, realX, realZ);
+
+            if(decorator != null)
+            {
+                if(!decorator.isStacking())
+                {
+                    data.set(x, height, z, decorator.getBlockData100(biome, getRng(), realX, realZ, getData()));
+                }
+                else
+                {
+                    int stack = decorator.getHeight(getRng().nextParallelRNG(Cache.key(realX, realZ)), realX, realZ, getData());
+                    stack = Math.min(stack, getDimension().getFluidHeight() - height + 2);
+                    //Iris.info("Stack at " + realX + "," + realZ + " is " + stack);
+                    BlockData top = decorator.getBlockDataForTop(biome, getRng(), realX, realZ, getData());
+                    BlockData fill = decorator.getBlockData100(biome, getRng(), realX, realZ, getData());
+                    for(int i = 0; i < stack; i++)
+                    {
+                        data.set(x, height+i, z, i == stack-1 ? top : fill);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/volmit/iris/generator/decorator/IrisSeaFloorDecorator.java
+++ b/src/main/java/com/volmit/iris/generator/decorator/IrisSeaFloorDecorator.java
@@ -1,6 +1,5 @@
 package com.volmit.iris.generator.decorator;
 
-import com.volmit.iris.Iris;
 import com.volmit.iris.object.DecorationPart;
 import com.volmit.iris.object.IrisBiome;
 import com.volmit.iris.object.IrisDecorator;
@@ -31,12 +30,14 @@ public class IrisSeaFloorDecorator extends IrisEngineDecorator
                 {
                     int stack = decorator.getHeight(getRng().nextParallelRNG(Cache.key(realX, realZ)), realX, realZ, getData());
                     stack = Math.min(stack, getDimension().getFluidHeight() - height + 2);
-                    //Iris.info("Stack at " + realX + "," + realZ + " is " + stack);
+
                     BlockData top = decorator.getBlockDataForTop(biome, getRng(), realX, realZ, getData());
                     BlockData fill = decorator.getBlockData100(biome, getRng(), realX, realZ, getData());
+
                     for(int i = 0; i < stack; i++)
                     {
-                        data.set(x, height+i, z, i == stack-1 ? top : fill);
+                        double threshold = ((double)i) / (stack - 1);
+                        data.set(x, height+i, z, threshold >= decorator.getTopThreshold() ? top : fill);
                     }
                 }
             }

--- a/src/main/java/com/volmit/iris/generator/decorator/IrisSeaSurfaceDecorator.java
+++ b/src/main/java/com/volmit/iris/generator/decorator/IrisSeaSurfaceDecorator.java
@@ -30,9 +30,12 @@ public class IrisSeaSurfaceDecorator extends IrisEngineDecorator
                     {
                         int stack = decorator.getHeight(getRng().nextParallelRNG(Cache.key(realX, realZ)), realX, realZ, getData());
 
+                        BlockData top = decorator.getBlockDataForTop(biome, getRng(), realX, realZ, getData());
+                        BlockData fill = decorator.getBlockData100(biome, getRng(), realX, realZ, getData());
                         for(int i = 0; i < stack; i++)
                         {
-                            data.set(x, getDimension().getFluidHeight()+1+i, z, i == stack-1 ? decorator.getBlockDataForTop(biome, getRng(), realX+i, realZ-i, getData()) : decorator.getBlockData100(biome, getRng(), realX+i, realZ-i, getData()));
+                            double threshold = ((double)i) / (stack - 1);
+                            data.set(x, getDimension().getFluidHeight()+1+i, z, threshold >= decorator.getTopThreshold() ? top : fill);
                         }
                     }
                 }

--- a/src/main/java/com/volmit/iris/generator/decorator/IrisSeaSurfaceDecorator.java
+++ b/src/main/java/com/volmit/iris/generator/decorator/IrisSeaSurfaceDecorator.java
@@ -16,28 +16,24 @@ public class IrisSeaSurfaceDecorator extends IrisEngineDecorator
 
     @Override
     public void decorate(int x, int z, int realX, int realX1, int realX_1, int realZ, int realZ1, int realZ_1, Hunk<BlockData> data, IrisBiome biome, int height, int max) {
-        if(height > getDimension().getFluidHeight()) {
+        IrisDecorator decorator = getDecorator(biome, realX, realZ);
+
+        if(decorator != null)
+        {
+            if(!decorator.isStacking())
             {
-                IrisDecorator decorator = getDecorator(biome, realX, realZ);
+                data.set(x, getDimension().getFluidHeight()+1, z, decorator.getBlockData100(biome, getRng(), realX, realZ, getData()));
+            }
+            else
+            {
+                int stack = decorator.getHeight(getRng().nextParallelRNG(Cache.key(realX, realZ)), realX, realZ, getData());
 
-                if(decorator != null)
+                BlockData top = decorator.getBlockDataForTop(biome, getRng(), realX, realZ, getData());
+                BlockData fill = decorator.getBlockData100(biome, getRng(), realX, realZ, getData());
+                for(int i = 0; i < stack; i++)
                 {
-                    if(!decorator.isStacking())
-                    {
-                        data.set(x, getDimension().getFluidHeight()+1, z, decorator.getBlockData100(biome, getRng(), realX, realZ, getData()));
-                    }
-                    else
-                    {
-                        int stack = decorator.getHeight(getRng().nextParallelRNG(Cache.key(realX, realZ)), realX, realZ, getData());
-
-                        BlockData top = decorator.getBlockDataForTop(biome, getRng(), realX, realZ, getData());
-                        BlockData fill = decorator.getBlockData100(biome, getRng(), realX, realZ, getData());
-                        for(int i = 0; i < stack; i++)
-                        {
-                            double threshold = ((double)i) / (stack - 1);
-                            data.set(x, getDimension().getFluidHeight()+1+i, z, threshold >= decorator.getTopThreshold() ? top : fill);
-                        }
-                    }
+                    double threshold = ((double)i) / (stack - 1);
+                    data.set(x, getDimension().getFluidHeight() + 1 + i, z, threshold >= decorator.getTopThreshold() ? top : fill);
                 }
             }
         }

--- a/src/main/java/com/volmit/iris/generator/decorator/IrisSeaSurfaceDecorator.java
+++ b/src/main/java/com/volmit/iris/generator/decorator/IrisSeaSurfaceDecorator.java
@@ -16,7 +16,7 @@ public class IrisSeaSurfaceDecorator extends IrisEngineDecorator
 
     @Override
     public void decorate(int x, int z, int realX, int realX1, int realX_1, int realZ, int realZ1, int realZ_1, Hunk<BlockData> data, IrisBiome biome, int height, int max) {
-        if(height < getDimension().getFluidHeight()) {
+        if(height > getDimension().getFluidHeight()) {
             {
                 IrisDecorator decorator = getDecorator(biome, realX, realZ);
 
@@ -26,10 +26,9 @@ public class IrisSeaSurfaceDecorator extends IrisEngineDecorator
                     {
                         data.set(x, getDimension().getFluidHeight()+1, z, decorator.getBlockData100(biome, getRng(), realX, realZ, getData()));
                     }
-
                     else
                     {
-                        int stack = Math.min(getRng().nextParallelRNG(Cache.key(realX, realZ)).i(decorator.getStackMin(), decorator.getStackMax()), max);
+                        int stack = decorator.getHeight(getRng().nextParallelRNG(Cache.key(realX, realZ)), realX, realZ, getData());
 
                         for(int i = 0; i < stack; i++)
                         {

--- a/src/main/java/com/volmit/iris/generator/decorator/IrisShoreLineDecorator.java
+++ b/src/main/java/com/volmit/iris/generator/decorator/IrisShoreLineDecorator.java
@@ -36,9 +36,13 @@ public class IrisShoreLineDecorator extends IrisEngineDecorator
                     {
                         int stack = decorator.getHeight(getRng().nextParallelRNG(Cache.key(realX, realZ)), realX, realZ, getData());
 
+                        BlockData top = decorator.getBlockDataForTop(biome, getRng(), realX, realZ, getData());
+                        BlockData fill = decorator.getBlockData100(biome, getRng(), realX, realZ, getData());
+
                         for(int i = 0; i < stack; i++)
                         {
-                            data.set(x, height+1+i, z, i == stack-1 ? decorator.getBlockDataForTop(biome, getRng(), realX+i, realZ-i, getData()) : decorator.getBlockData100(biome, getRng(), realX+i, realZ-i, getData()));
+                            double threshold = ((double)i) / (stack - 1);
+                            data.set(x, height+1+i, z, threshold >= decorator.getTopThreshold() ? top : fill);
                         }
                     }
                 }

--- a/src/main/java/com/volmit/iris/generator/decorator/IrisShoreLineDecorator.java
+++ b/src/main/java/com/volmit/iris/generator/decorator/IrisShoreLineDecorator.java
@@ -32,10 +32,9 @@ public class IrisShoreLineDecorator extends IrisEngineDecorator
                     {
                         data.set(x, height+1, z, decorator.getBlockData100(biome, getRng(), realX, realZ, getData()));
                     }
-
                     else
                     {
-                        int stack = Math.min(getRng().nextParallelRNG(Cache.key(realX, realZ)).i(decorator.getStackMin(), decorator.getStackMax()), max);
+                        int stack = decorator.getHeight(getRng().nextParallelRNG(Cache.key(realX, realZ)), realX, realZ, getData());
 
                         for(int i = 0; i < stack; i++)
                         {

--- a/src/main/java/com/volmit/iris/generator/decorator/IrisSurfaceDecorator.java
+++ b/src/main/java/com/volmit/iris/generator/decorator/IrisSurfaceDecorator.java
@@ -70,15 +70,13 @@ public class IrisSurfaceDecorator extends IrisEngineDecorator
                 }
 
                 int stack = decorator.getHeight(getRng().nextParallelRNG(Cache.key(realX, realZ)), realX, realZ, getData());
+                BlockData top = decorator.getBlockDataForTop(biome, getRng(), realX, realZ, getData());
+                BlockData fill = decorator.getBlockData100(biome, getRng(), realX, realZ, getData());
 
                 for(int i = 0; i < stack; i++)
                 {
-                    bd = i == stack-1 ? decorator.getBlockDataForTop(biome, getRng(), realX+i, realZ-i, getData()) : decorator.getBlockData100(biome, getRng(), realX+i, realZ-i, getData());
-
-                    if(bd == null && i == stack-1)
-                    {
-                        bd = decorator.getBlockData100(biome, getRng(), realX+i, realZ-i, getData());
-                    }
+                    double threshold = ((double)i) / (stack - 1);
+                    bd = threshold >= decorator.getTopThreshold() ? top : fill;
 
                     if(bd == null)
                     {

--- a/src/main/java/com/volmit/iris/generator/decorator/IrisSurfaceDecorator.java
+++ b/src/main/java/com/volmit/iris/generator/decorator/IrisSurfaceDecorator.java
@@ -62,14 +62,14 @@ public class IrisSurfaceDecorator extends IrisEngineDecorator
                 data.set(x, height+1, z, bd);
 
             }
-
-            else {
+            else
+            {
                 if (height < getDimension().getFluidHeight())
                 {
                     max = getDimension().getFluidHeight() - height;
                 }
 
-                int stack = Math.min(getRng().nextParallelRNG(Cache.key(realX, realZ)).i(decorator.getStackMin(), decorator.getStackMax()), max);
+                int stack = decorator.getHeight(getRng().nextParallelRNG(Cache.key(realX, realZ)), realX, realZ, getData());
 
                 for(int i = 0; i < stack; i++)
                 {

--- a/src/main/java/com/volmit/iris/manager/command/world/CommandIrisPregen.java
+++ b/src/main/java/com/volmit/iris/manager/command/world/CommandIrisPregen.java
@@ -104,7 +104,7 @@ public class CommandIrisPregen extends MortarCommand
 				}
 			}
 			try {
-				new Pregenerator(world, getVal(args[0]));
+				new Pregenerator(world, getVal(args[0]) * 2);
 			} catch (NumberFormatException e){
 				sender.sendMessage("Invalid argument in command");
 				return true;
@@ -120,7 +120,7 @@ public class CommandIrisPregen extends MortarCommand
 		else
 		{
 			if (args.length < 1){
-				sender.sendMessage("Please specify the size of the pregen and the name of the world. E.g. /ir pregen 5k world");
+				sender.sendMessage("Please specify the radius of the pregen and the name of the world. E.g. /ir pregen 5k world");
 				return true;
 			}
 			if (args.length < 2){
@@ -129,7 +129,7 @@ public class CommandIrisPregen extends MortarCommand
 			}
 			World world = Bukkit.getWorld(args[1]);
 			try {
-				new Pregenerator(world, getVal(args[0]));
+				new Pregenerator(world, getVal(args[0]) * 2);
 			} catch (NumberFormatException e){
 				sender.sendMessage("Invalid argument in command");
 				return true;
@@ -166,6 +166,6 @@ public class CommandIrisPregen extends MortarCommand
 	@Override
 	protected String getArgsUsage()
 	{
-		return "[width]";
+		return "[radius]";
 	}
 }

--- a/src/main/java/com/volmit/iris/object/DecorationPart.java
+++ b/src/main/java/com/volmit/iris/object/DecorationPart.java
@@ -18,6 +18,10 @@ public enum DecorationPart
 	@DontObfuscate
 	SEA_SURFACE,
 
+	@Desc("Targets the sea floor (entire placement must be bellow sea level)")
+	@DontObfuscate
+	SEA_FLOOR,
+
 	@Desc("Decorates on cave & carving ceilings or underside of overhangs")
 	@DontObfuscate
 	CEILING,

--- a/src/main/java/com/volmit/iris/object/IrisDecorator.java
+++ b/src/main/java/com/volmit/iris/object/IrisDecorator.java
@@ -198,7 +198,9 @@ public class IrisDecorator
 				BlockData bx = i.getBlockData(data);
 				if(bx != null)
 				{
-					blockData.add(bx);
+					for (int n = 0; n < i.getWeight(); n++) {
+						blockData.add(bx);
+					}
 				}
 			}
 
@@ -216,7 +218,9 @@ public class IrisDecorator
 				BlockData bx = i.getBlockData(data);
 				if(bx != null)
 				{
-					blockDataTops.add(bx);
+					for (int n = 0; n < i.getWeight(); n++) {
+						blockDataTops.add(bx);
+					}
 				}
 			}
 

--- a/src/main/java/com/volmit/iris/object/IrisDecorator.java
+++ b/src/main/java/com/volmit/iris/object/IrisDecorator.java
@@ -85,7 +85,7 @@ public class IrisDecorator
 			return stackMin;
 		}
 
-		return getHeightGenerator(rng, data).fit(stackMin, stackMax, x / heightVariance.getZoom(), z / heightVariance.getZoom());
+		return getHeightGenerator(rng, data).fit(stackMin, stackMax, x / heightVariance.getZoom(), z / heightVariance.getZoom()) + 1;
 	}
 
 	public CNG getHeightGenerator(RNG rng, IrisDataManager data)
@@ -134,7 +134,7 @@ public class IrisDecorator
 				return getBlockData(data).get(0);
 			}
 
-			return getVarianceGenerator(rng, data).fit(getBlockData(data), zz, xx); //X and Z must be switched
+			return getVarianceGenerator(rng, data).fit(getBlockData(data), z, x); //X and Z must be switched
 		}
 
 		return null;
@@ -162,7 +162,7 @@ public class IrisDecorator
 			return getBlockData(data).get(0);
 		}
 
-		return getVarianceGenerator(rng, data).fit(getBlockData(data), zz, xx).clone(); //X and Z must be switched
+		return getVarianceGenerator(rng, data).fit(getBlockData(data), z, x).clone(); //X and Z must be switched
 	}
 
 	public BlockData getBlockDataForTop(IrisBiome b, RNG rng, double x, double z, IrisDataManager data)
@@ -182,7 +182,7 @@ public class IrisDecorator
 				return getBlockDataTops(data).get(0);
 			}
 
-			return getVarianceGenerator(rng, data).fit(getBlockDataTops(data), zz, xx); //X and Z must be switched
+			return getVarianceGenerator(rng, data).fit(getBlockDataTops(data), z, x); //X and Z must be switched
 		}
 
 		return null;

--- a/src/main/java/com/volmit/iris/object/IrisDecorator.java
+++ b/src/main/java/com/volmit/iris/object/IrisDecorator.java
@@ -72,6 +72,13 @@ public class IrisDecorator
 	@Desc("The palette of blocks used at the very top of a 'stackMax' of higher than 1. For example, bamboo tops.")
 	private KList<IrisBlockData> topPalette = new KList<IrisBlockData>();
 
+	@DependsOn("topPalette")
+	@MinNumber(0.01)
+	@MaxNumber(1.0)
+	@DontObfuscate
+	@Desc("When the stack passes the top threshold, the top palette will start being used instead of the normal palette.")
+	private double topThreshold = 1.0;
+
 	private final transient AtomicCache<CNG> layerGenerator = new AtomicCache<>();
 	private final transient AtomicCache<CNG> varianceGenerator = new AtomicCache<>();
 	private final transient AtomicCache<CNG> heightGenerator = new AtomicCache<>();

--- a/src/main/java/com/volmit/iris/object/IrisDecorator.java
+++ b/src/main/java/com/volmit/iris/object/IrisDecorator.java
@@ -54,22 +54,6 @@ public class IrisDecorator
 	@Desc("The maximum repeat stack height")
 	private int stackMax = 1;
 
-	@MinNumber(0.0001)
-	@DontObfuscate
-	@Desc("The zoom is for zooming in or out wispy dispersions. Makes patches bigger the higher this zoom value is")
-	private double zoom = 1;
-
-	@MinNumber(0.0001)
-	@DontObfuscate
-	@Desc("The zoom is for zooming in or out variance. Makes patches have more or less of one type.")
-	private double varianceZoom = 1;
-
-	@DependsOn({"stackMin", "stackMax"})
-	@MinNumber(0.0001)
-	@DontObfuscate
-	@Desc("The vertical zoom is for wispy stack heights. Zooming this in makes stack heights more slowly change over a distance")
-	private double verticalZoom = 1;
-
 	@Required
 	@MinNumber(0)
 	@MaxNumber(1)
@@ -101,7 +85,7 @@ public class IrisDecorator
 			return stackMin;
 		}
 
-		return getHeightGenerator(rng, data).fit(stackMin, stackMax, x / verticalZoom, z / verticalZoom);
+		return getHeightGenerator(rng, data).fit(stackMin, stackMax, x / heightVariance.getZoom(), z / heightVariance.getZoom());
 	}
 
 	public CNG getHeightGenerator(RNG rng, IrisDataManager data)
@@ -123,7 +107,7 @@ public class IrisDecorator
 				variance.create(
 						rng.nextParallelRNG((int) (getBlockData(data).size())))
 
-						.scale(1D / varianceZoom));
+						.scale(1D / variance.getZoom()));
 	}
 
 	public KList<IrisBlockData> add(String b)
@@ -140,8 +124,8 @@ public class IrisDecorator
 			return null;
 		}
 
-		double xx = x / getZoom();
-		double zz = z / getZoom();
+		double xx = x / style.getZoom();
+		double zz = z / style.getZoom();
 
 		if(getGenerator(rng, data).fitDouble(0D, 1D, xx, zz) <= chance)
 		{
@@ -150,7 +134,7 @@ public class IrisDecorator
 				return getBlockData(data).get(0);
 			}
 
-			return getVarianceGenerator(rng, data).fit(getBlockData(data), xx, zz);
+			return getVarianceGenerator(rng, data).fit(getBlockData(data), zz, xx); //X and Z must be switched
 		}
 
 		return null;
@@ -169,8 +153,8 @@ public class IrisDecorator
 
 		if(!getVarianceGenerator(rng, data).isStatic())
 		{
-			xx = x / getZoom();
-			zz = z / getZoom();
+			xx = x / style.getZoom();
+			zz = z / style.getZoom();
 		}
 
 		if(getBlockData(data).size() == 1)
@@ -178,7 +162,7 @@ public class IrisDecorator
 			return getBlockData(data).get(0);
 		}
 
-		return getVarianceGenerator(rng, data).fit(getBlockData(data), xx, zz).clone();
+		return getVarianceGenerator(rng, data).fit(getBlockData(data), zz, xx).clone(); //X and Z must be switched
 	}
 
 	public BlockData getBlockDataForTop(IrisBiome b, RNG rng, double x, double z, IrisDataManager data)
@@ -188,8 +172,8 @@ public class IrisDecorator
 			return null;
 		}
 
-		double xx = x / getZoom();
-		double zz = z / getZoom();
+		double xx = x / style.getZoom();
+		double zz = z / style.getZoom();
 
 		if(getGenerator(rng, data).fitDouble(0D, 1D, xx, zz) <= chance)
 		{
@@ -198,7 +182,7 @@ public class IrisDecorator
 				return getBlockDataTops(data).get(0);
 			}
 
-			return getVarianceGenerator(rng, data).fit(getBlockDataTops(data), xx, zz);
+			return getVarianceGenerator(rng, data).fit(getBlockDataTops(data), zz, xx); //X and Z must be switched
 		}
 
 		return null;

--- a/src/main/java/com/volmit/iris/util/V.java
+++ b/src/main/java/com/volmit/iris/util/V.java
@@ -106,6 +106,10 @@ public class V
 		return null;
 	}
 
+	public Object getSelf() {
+		return o;
+	}
+
 	public Object invoke(String method, Object... parameters)
 	{
 		KList<Class<?>> par = new KList<Class<?>>();


### PR DESCRIPTION
- Added SEA_FLOOR type to decorators which will only place bellow sea level/in water (kelp, sea grass)
- Implemented CEILING type to decorators, which will allow stacked blocks to place from the top down
- Added `topThreshold` option to decorators. Allows stacked blocks to start using the top palette for x percent of the stack
- Fixed decorators using the same RNG when picking from a pool of blocks as the RNG used to place it. This caused it to only use pool entries above the placement chance threshold. (E.g. a flower pool with a 0.15 chance to place will only use the first 0.15 of the pool of flowers since the RNG is the same)
- Fixed height variance not being implemented properly on stacked blocks
- Fixed palette weight not working
- Removed `zoom`, `verticalZoom` and `varianceZoom` properties from decorators. Zooms can be done inside the individual styles instead.

Dev notes:
- It's very important from now on that in decorators, the X and Z remain switched when getting noise so that the result of the noise is not exactly the same as the noise that choose if the decor should be placed or not
- This WILL require updates to the overworld pack as fixing some of the bugs here made some workarounds in the overworld pack kinda break. Some of these are coming in a minute so hold onto your pants