### PR TITLE
Fix sender.player() call without checking if player

### DIFF
--- a/src/main/java/com/volmit/iris/core/IrisProject.java
+++ b/src/main/java/com/volmit/iris/core/IrisProject.java
@@ -273,8 +273,9 @@ public class IrisProject {
                     break;
                 }
             }
-
-            sender.player().spigot().sendMessage(ChatMessageType.ACTION_BAR, TextComponent.fromLegacyText(C.WHITE + "Generation Complete"));
+            if (sender.isPlayer()) {
+                sender.player().spigot().sendMessage(ChatMessageType.ACTION_BAR, TextComponent.fromLegacyText(C.WHITE + "Generation Complete"));
+            }
         });
 
         //@builder


### PR DESCRIPTION
Dan, you even put it in the comment of the function yourself.
`Force cast to player (be sure to check first)`