### PR TITLE
Free some workspace restrictions that allow users to set them themselves

### DIFF
--- a/src/main/java/com/volmit/iris/core/IrisProject.java
+++ b/src/main/java/com/volmit/iris/core/IrisProject.java
@@ -354,8 +354,6 @@ public class IrisProject {
         folders.put(folder);
         ws.put("folders", folders);
         JSONObject settings = new JSONObject();
-        settings.put("workbench.colorTheme", "Monokai");
-        settings.put("workbench.preferredDarkColorTheme", "Solarized Dark");
         settings.put("workbench.tips.enabled", false);
         settings.put("workbench.tree.indent", 24);
         settings.put("files.autoSave", "onFocusChange");
@@ -375,7 +373,7 @@ public class IrisProject {
         jc.put("editor.quickSuggestions", st);
         jc.put("editor.suggest.insertMode", "replace");
         settings.put("[json]", jc);
-        settings.put("json.maxItemsComputed", 30000);
+        settings.put("json.maxItemsComputed", 50000);
         JSONArray schemas = new JSONArray();
         IrisDataManager dm = new IrisDataManager(getPath());
         schemas.put(getSchemaEntry(IrisDimension.class, dm, "/dimensions/*.json", "/dimensions/*/*.json", "/dimensions/*/*/*.json"));

--- a/src/main/java/com/volmit/iris/core/IrisProject.java
+++ b/src/main/java/com/volmit/iris/core/IrisProject.java
@@ -361,7 +361,6 @@ public class IrisProject {
         jc.put("editor.autoIndent", "brackets");
         jc.put("editor.acceptSuggestionOnEnter", "smart");
         jc.put("editor.cursorSmoothCaretAnimation", true);
-        jc.put("editor.dragAndDrop", false);
         jc.put("files.trimTrailingWhitespace", true);
         jc.put("diffEditor.ignoreTrimWhitespace", true);
         jc.put("files.trimFinalNewlines", true);


### PR DESCRIPTION
Everything still functions properly, but stuff like editor style and a drag-drop restriction have been released, and the tooltip definition limit have been upped (it still performs well. Takes a bit more memory but allows more tooltips to be properly shown