### PR TITLE
Debug instead of uncaught throw EOFExc. & make error file even if !debug

### DIFF
--- a/src/main/java/com/volmit/iris/Iris.java
+++ b/src/main/java/com/volmit/iris/Iris.java
@@ -582,26 +582,24 @@ public class Iris extends VolmitPlugin implements Listener {
     }
 
     public static synchronized void reportError(Throwable e) {
-        if (IrisSettings.get().getGeneral().isDebug()) {
-            String n = e.getClass().getCanonicalName() + "-" + e.getStackTrace()[0].getClassName() + "-" + e.getStackTrace()[0].getLineNumber();
+        String n = e.getClass().getCanonicalName() + "-" + e.getStackTrace()[0].getClassName() + "-" + e.getStackTrace()[0].getLineNumber();
 
-            if (e.getCause() != null) {
-                n += "-" + e.getCause().getStackTrace()[0].getClassName() + "-" + e.getCause().getStackTrace()[0].getLineNumber();
-            }
-
-            File f = instance.getDataFile("debug", "caught-exceptions", n + ".txt");
-
-            if (!f.exists()) {
-                J.attempt(() -> {
-                    PrintWriter pw = new PrintWriter(f);
-                    pw.println("Thread: " + Thread.currentThread().getName());
-                    pw.println("First: " + new Date(M.ms()));
-                    e.printStackTrace(pw);
-                    pw.close();
-                });
-            }
-
-            Iris.debug("Exception Logged: " + e.getClass().getSimpleName() + ": " + C.RESET + "" + C.LIGHT_PURPLE + e.getMessage());
+        if (e.getCause() != null) {
+            n += "-" + e.getCause().getStackTrace()[0].getClassName() + "-" + e.getCause().getStackTrace()[0].getLineNumber();
         }
+
+        File f = instance.getDataFile("debug", "caught-exceptions", n + ".txt");
+
+        if (!f.exists()) {
+            J.attempt(() -> {
+                PrintWriter pw = new PrintWriter(f);
+                pw.println("Thread: " + Thread.currentThread().getName());
+                pw.println("First: " + new Date(M.ms()));
+                e.printStackTrace(pw);
+                pw.close();
+            });
+        }
+
+        Iris.debug("Exception Logged: " + e.getClass().getSimpleName() + ": " + C.RESET + "" + C.LIGHT_PURPLE + e.getMessage());
     }
 }

--- a/src/main/java/com/volmit/iris/engine/parallax/ParallaxChunkMeta.java
+++ b/src/main/java/com/volmit/iris/engine/parallax/ParallaxChunkMeta.java
@@ -19,6 +19,7 @@
 package com.volmit.iris.engine.parallax;
 
 import com.google.gson.Gson;
+import com.volmit.iris.Iris;
 import com.volmit.iris.engine.hunk.io.HunkIOAdapter;
 import com.volmit.iris.engine.hunk.io.PaletteHunkIOAdapter;
 import com.volmit.iris.engine.object.IrisFeaturePositional;
@@ -28,6 +29,7 @@ import lombok.Data;
 
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
+import java.io.EOFException;
 import java.io.IOException;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Function;
@@ -71,7 +73,11 @@ public class ParallaxChunkMeta {
             int c = din.readInt();
 
             for (int i = 0; i < c; i++) {
-                pcm.getFeatures().add(gson.fromJson(din.readUTF(), IrisFeaturePositional.class));
+                try {
+                    pcm.getFeatures().add(gson.fromJson(din.readUTF(), IrisFeaturePositional.class));
+                } catch (EOFException e){
+                    Iris.reportError(e);
+                }
             }
 
             return pcm;


### PR DESCRIPTION
Debugs End of file exceptions instead of throwing them to the console (so people shut up about them, oh my god)
Removes debug check from Iris.reportError so it creates the error log file log file even if debug mode is not enabled. The Iris.debug function only runs if the setting is on, so all this does is create the file, should not print the message to console.