### PR TITLE
Remove the gradient if an error occurs with sender.send

### DIFF
--- a/src/main/java/com/volmit/iris/Iris.java
+++ b/src/main/java/com/volmit/iris/Iris.java
@@ -484,7 +484,7 @@ public class Iris extends VolmitPlugin implements Listener {
             sender.sendMessage(string);
         } catch (Throwable e) {
             try {
-                System.out.println(string);
+                System.out.println(instance.getTag() + string.replaceAll("(<([^>]+)>)", ""));
             } catch (Throwable ignored1) {
 
             }

--- a/src/main/java/com/volmit/iris/core/project/loader/ResourceLoader.java
+++ b/src/main/java/com/volmit/iris/core/project/loader/ResourceLoader.java
@@ -71,7 +71,7 @@ public class ResourceLoader<T extends IrisRegistrant> {
         this.root = root;
         this.folderName = folderName;
         loadCache = new KMap<>();
-        Iris.debug("Loader<" + C.GREEN + resourceTypeName + C.LIGHT_PURPLE + "> created in " + C.RED + "IDM/" + manager.getId() + C.LIGHT_PURPLE + " on " + C.WHITE + manager.getDataFolder().getPath());
+        Iris.debug("Loader<" + C.GREEN + resourceTypeName + C.LIGHT_PURPLE + "> created in " + C.RED + "IDM/" + manager.getId() + C.LIGHT_PURPLE + " on " + C.GRAY + manager.getDataFolder().getPath());
     }
 
     public JSONObject buildSchema() {


### PR DESCRIPTION
Otherwise, the raw gradient text is printed to the console, which is bad.