### PR TITLE
Check if the world is a studio then evac only

### DIFF
--- a/src/main/java/com/volmit/iris/core/project/IrisProject.java
+++ b/src/main/java/com/volmit/iris/core/project/IrisProject.java
@@ -177,7 +177,9 @@ public class IrisProject {
 
     public void close() {
         Iris.debug("Closing Active Provider");
-        IrisToolbelt.evacuate(activeProvider.getTarget().getWorld().realWorld());
+        if (activeProvider.isStudio()){
+            IrisToolbelt.evacuate(activeProvider.getTarget().getWorld().realWorld());
+        }
         activeProvider.close();
         File folder = activeProvider.getTarget().getWorld().worldFolder();
         Iris.linkMultiverseCore.removeFromConfig(activeProvider.getTarget().getWorld().name());


### PR DESCRIPTION
It's really annoying to be moved out of a normal Iris world (non-studio) when /iris reload.
Idk if this is safe in regards to chunkgen, but I assume /reload confirm locks generation