### PR TITLE
fixes

### DIFF
--- a/src/main/java/com/volmit/iris/core/commands/CommandStudio.java
+++ b/src/main/java/com/volmit/iris/core/commands/CommandStudio.java
@@ -326,7 +326,7 @@ public class CommandStudio implements DecreeExecutor {
         engine().getExecution().execute(script.getLoadKey());
     }
 
-    @Decree(description = "Open the noise explorer (External GUI)", aliases = "nmap")
+    @Decree(description = "Open the noise explorer (External GUI)", aliases = {"nmap", "n"})
     public void noise() {
         if (noGUI()) return;
         sender().sendMessage(C.GREEN + "Opening Noise Explorer!");

--- a/src/main/java/com/volmit/iris/core/commands/CommandWhat.java
+++ b/src/main/java/com/volmit/iris/core/commands/CommandWhat.java
@@ -39,7 +39,7 @@ import org.bukkit.block.data.BlockData;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
-@Decree(name = "what", origin = DecreeOrigin.PLAYER, studio = true, description = "Iris What?")
+@Decree(name = "what", origin = DecreeOrigin.PLAYER, studio = true, description = "Iris What?", aliases = "w")
 public class CommandWhat implements DecreeExecutor {
     @Decree(description = "What is in my hand?", origin = DecreeOrigin.PLAYER)
     public void hand() {
@@ -62,7 +62,7 @@ public class CommandWhat implements DecreeExecutor {
         }
     }
 
-    @Decree(description = "What biome am i in?", origin = DecreeOrigin.PLAYER)
+    @Decree(description = "What biome am i in?", origin = DecreeOrigin.PLAYER, aliases = "b")
     public void biome() {
         try {
             IrisBiome b = engine().getBiome(player().getLocation().getBlockX(), player().getLocation().getBlockY(), player().getLocation().getBlockZ());


### PR DESCRIPTION
The aliases are set so they are picked over other commands/categories.
E.g. `/ir w b` wouldn't work because the `w` is triggered with `jigsaW`, no joke.
Same for `b` pointing to `block` instead of (the more commonly used) `biome`.