### PR TITLE
Only print stacktrace when non-ZLIB exception

### DIFF
--- a/src/main/java/com/volmit/iris/util/mantle/Mantle.java
+++ b/src/main/java/com/volmit/iris/util/mantle/Mantle.java
@@ -41,6 +41,7 @@ import com.volmit.iris.util.parallel.MultiBurst;
 import lombok.Getter;
 import org.bukkit.Chunk;
 
+import java.io.EOFException;
 import java.io.File;
 import java.io.IOException;
 import java.util.Map;
@@ -537,7 +538,9 @@ public class Mantle {
                 } catch(Throwable e) {
                     Iris.error("Failed to read Tectonic Plate " + file.getAbsolutePath() + " creating a new chunk instead.");
                     Iris.reportError(e);
-                    e.printStackTrace();
+                    if (!(e instanceof EOFException)) {
+                        e.printStackTrace();
+                    }
                     Iris.panic();
                     region = new TectonicPlate(worldHeight, x, z);
                     loadedRegions.put(k, region);


### PR DESCRIPTION
Prevents stacktrace prints on known ZLIB tectonic plate read error, as seen here: https://pastebin.com/Rdb8KYsc