### PR TITLE
Recoloring command for broken custom colors WIP

### DIFF
--- a/src/main/java/com/volmit/iris/core/commands/CommandIris.java
+++ b/src/main/java/com/volmit/iris/core/commands/CommandIris.java
@@ -294,7 +294,7 @@ public class CommandIris implements DecreeExecutor {
                     for(int j = -radius; j <= radius; j++) {
                         int finalJ = j;
                         int finalI = i;
-                        b.queue(() -> plat.injectChunkReplacement(player().getWorld(), finalI + cx.getX(), finalJ + cx.getZ(), (f) -> {
+                        b.queue(() -> plat.injectChunkRecoloring(player().getWorld(), finalI + cx.getX(), finalJ + cx.getZ(), (f) -> {
                             synchronized(js) {
                                 js.add(f);
                             }

--- a/src/main/java/com/volmit/iris/engine/mode/ModeRecolor.java
+++ b/src/main/java/com/volmit/iris/engine/mode/ModeRecolor.java
@@ -1,0 +1,15 @@
+package com.volmit.iris.engine.mode;
+
+import com.volmit.iris.engine.actuator.IrisBiomeActuator;
+import com.volmit.iris.engine.framework.Engine;
+import com.volmit.iris.engine.framework.IrisEngineMode;
+
+public class ModeRecolor extends IrisEngineMode {
+    public ModeRecolor(Engine engine) {
+        super(engine);
+
+        var biome = new IrisBiomeActuator(getEngine());
+
+        registerStage(burst((x, z, k, p, m) -> biome.actuate(x, z, p, m)));
+    }
+}

--- a/src/main/java/com/volmit/iris/engine/platform/BukkitChunkGenerator.java
+++ b/src/main/java/com/volmit/iris/engine/platform/BukkitChunkGenerator.java
@@ -199,7 +199,6 @@ public class BukkitChunkGenerator extends ChunkGenerator implements PlatformChun
 
     @Override
     public void injectChunkRecoloring(World world, int x, int z, Consumer<Runnable> jobs) {
-        Iris.error("Non-implemented method: InjectChunkRecoloring in " + getClass().getSimpleName());
         try {
             loadLock.acquire();
             IrisBiomeStorage st = new IrisBiomeStorage();

--- a/src/main/java/com/volmit/iris/engine/platform/BukkitChunkGenerator.java
+++ b/src/main/java/com/volmit/iris/engine/platform/BukkitChunkGenerator.java
@@ -25,6 +25,7 @@ import com.volmit.iris.engine.IrisEngine;
 import com.volmit.iris.engine.data.chunk.TerrainChunk;
 import com.volmit.iris.engine.framework.Engine;
 import com.volmit.iris.engine.framework.EngineTarget;
+import com.volmit.iris.engine.mode.ModeRecolor;
 import com.volmit.iris.engine.object.IrisDimension;
 import com.volmit.iris.engine.object.IrisWorld;
 import com.volmit.iris.engine.object.StudioMode;
@@ -193,6 +194,29 @@ public class BukkitChunkGenerator extends ChunkGenerator implements PlatformChun
                     d.setBlock(i, 0, j, Material.RED_GLAZED_TERRACOTTA.createBlockData());
                 }
             }
+        }
+    }
+
+    @Override
+    public void injectChunkRecoloring(World world, int x, int z, Consumer<Runnable> jobs) {
+        Iris.error("Non-implemented method: InjectChunkRecoloring in " + getClass().getSimpleName());
+        try {
+            loadLock.acquire();
+            IrisBiomeStorage st = new IrisBiomeStorage();
+            TerrainChunk tc = TerrainChunk.createUnsafe(world, st);
+            Hunk<BlockData> blocks = Hunk.view(tc);
+            Hunk<Biome> biomes = Hunk.view(tc, tc.getMinHeight(), tc.getMaxHeight());
+            this.world.bind(world);
+            new ModeRecolor(getEngine()).generate(x << 4, z << 4, blocks, biomes, true);
+            Iris.debug("Recolored " + x + " " + z);
+
+            loadLock.release();
+        } catch(Throwable e) {
+            loadLock.release();
+            Iris.error("======================================");
+            e.printStackTrace();
+            Iris.reportErrorChunk(x, z, e, "CHUNK");
+            Iris.error("======================================");
         }
     }
 

--- a/src/main/java/com/volmit/iris/engine/platform/HeadlessGenerator.java
+++ b/src/main/java/com/volmit/iris/engine/platform/HeadlessGenerator.java
@@ -108,6 +108,11 @@ public class HeadlessGenerator implements PlatformChunkGenerator {
 
     }
 
+    @Override
+    public void injectChunkRecoloring(World world, int x, int z, Consumer<Runnable> jobs) {
+
+    }
+
     @RegionCoordinates
     public void generateRegion(int x, int z) {
         generateRegion(x, z, null);

--- a/src/main/java/com/volmit/iris/engine/platform/PlatformChunkGenerator.java
+++ b/src/main/java/com/volmit/iris/engine/platform/PlatformChunkGenerator.java
@@ -43,6 +43,8 @@ public interface PlatformChunkGenerator extends Hotloadable, DataProvider {
 
     void injectChunkReplacement(World world, int x, int z, Consumer<Runnable> jobs);
 
+    void injectChunkRecoloring(World world, int x, int z, Consumer<Runnable> jobs);
+
     void close();
 
     boolean isStudio();


### PR DESCRIPTION
Users have been having trouble with custom colors going away after some time for (as far as my knowledge goes) unknown reasons.
To to help those that lose their colors get them back this PR introduces a new command: `/recolor <radius=5>`.
Please take a look at the code and properly test it. I am having dependency issues so I have not been able to test the code myself. WIP / UNTESTED