### PR TITLE
Remove cartographer villagers due to crashes

### DIFF
--- a/src/main/java/com/volmit/iris/core/service/VillageSVC.java
+++ b/src/main/java/com/volmit/iris/core/service/VillageSVC.java
@@ -20,14 +20,21 @@ package com.volmit.iris.core.service;
 
 import com.volmit.iris.Iris;
 import com.volmit.iris.core.tools.IrisToolbelt;
+import com.volmit.iris.engine.object.IrisDimension;
 import com.volmit.iris.engine.object.IrisVillagerOverride;
 import com.volmit.iris.engine.object.IrisVillagerTrade;
+import com.volmit.iris.util.format.C;
 import com.volmit.iris.util.plugin.IrisService;
+import com.volmit.iris.util.plugin.VolmitSender;
+import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.entity.Player;
 import org.bukkit.entity.Villager;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.entity.VillagerAcquireTradeEvent;
 import org.bukkit.event.entity.VillagerCareerChangeEvent;
+
+import java.util.List;
 
 public class VillageSVC implements IrisService {
     @Override
@@ -42,18 +49,45 @@ public class VillageSVC implements IrisService {
 
     @EventHandler
     public void on(VillagerCareerChangeEvent event) {
+
         if (!IrisToolbelt.isIrisWorld(event.getEntity().getWorld())) {
             return;
         }
 
-        if (!IrisToolbelt.access(event.getEntity().getWorld())
-                .getEngine().getDimension().isRemoveCartographersDueToCrash()) {
+        IrisDimension dim = IrisToolbelt.access(event.getEntity().getWorld())
+                .getEngine().getDimension();
+
+        if (!dim.isRemoveCartographersDueToCrash()) {
             return;
         }
 
         if (event.getProfession().equals(Villager.Profession.CARTOGRAPHER)) {
             event.setCancelled(true);
-            Iris.info("Cancelled Cartographer Villager to prevent server crash!");
+
+            Location eventLocation = event.getEntity().getLocation();
+
+            int radius = dim.getNotifyPlayersOfCartographerCancelledRadius();
+
+            if (radius == -1) {
+                return;
+            }
+
+            List<Player> playersInWorld = event.getEntity().getWorld().getPlayers();
+
+            String message = C.GOLD + "Iris does not allow cartographers in its world due to crashes.";
+
+            Iris.info("Cancelled Cartographer Villager to prevent server crash at " + eventLocation + "!");
+
+            if (radius == -2) {
+                playersInWorld.stream().map(VolmitSender::new).forEach(v -> v.sendMessage(message));
+            } else {
+                playersInWorld.forEach(p -> {
+                    if (p.getLocation().distance(eventLocation) < radius) {
+                        new VolmitSender(p).sendMessage(message);
+                    }
+                });
+            }
+
         }
     }
 

--- a/src/main/java/com/volmit/iris/core/service/VillageSVC.java
+++ b/src/main/java/com/volmit/iris/core/service/VillageSVC.java
@@ -24,8 +24,10 @@ import com.volmit.iris.engine.object.IrisVillagerOverride;
 import com.volmit.iris.engine.object.IrisVillagerTrade;
 import com.volmit.iris.util.plugin.IrisService;
 import org.bukkit.Material;
+import org.bukkit.entity.Villager;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.entity.VillagerAcquireTradeEvent;
+import org.bukkit.event.entity.VillagerCareerChangeEvent;
 
 public class VillageSVC implements IrisService {
     @Override
@@ -38,9 +40,28 @@ public class VillageSVC implements IrisService {
 
     }
 
-    /**
+    @EventHandler
+    public void on(VillagerCareerChangeEvent event) {
+        if (!IrisToolbelt.isIrisWorld(event.getEntity().getWorld())) {
+            return;
+        }
+
+        if (!IrisToolbelt.access(event.getEntity().getWorld())
+                .getEngine().getDimension().isRemoveCartographersDueToCrash()) {
+            return;
+        }
+
+        if (event.getProfession().equals(Villager.Profession.CARTOGRAPHER)) {
+            event.setCancelled(true);
+            Iris.info("Cancelled Cartographer Villager to prevent server crash!");
+        }
+    }
+
+    /*
      * Replace or disable villager trade add event to prevent explorer map
      */
+    /* Removed due to MC breaking stuff again. This event is now called after the cartographer maps are made,
+    so it can fuck right off.
     @EventHandler
     public void on(VillagerAcquireTradeEvent event) {
         if(!IrisToolbelt.isIrisWorld((event.getEntity().getWorld()))) {
@@ -71,4 +92,5 @@ public class VillageSVC implements IrisService {
         event.setRecipe(trade.convert());
         Iris.debug("Overrode cartographer trade with: " + trade + " to prevent allowing cartography map trades");
     }
+    */
 }

--- a/src/main/java/com/volmit/iris/core/service/VillageSVC.java
+++ b/src/main/java/com/volmit/iris/core/service/VillageSVC.java
@@ -43,11 +43,11 @@ public class VillageSVC implements IrisService {
      */
     @EventHandler
     public void on(VillagerAcquireTradeEvent event) {
-        if(!IrisToolbelt.isIrisWorld(event.getEntity().getWorld())) {
+        if(!IrisToolbelt.isIrisWorld((event.getEntity().getWorld()))) {
             return;
         }
 
-        Iris.info("Trade event: type " + event.getRecipe().getResult().getType() + " / meta " + event.getRecipe().getResult().getItemMeta() + " / data " + event.getRecipe().getResult().getData());
+        // Iris.info("Trade event: type " + event.getRecipe().getResult().getType() + " / meta " + event.getRecipe().getResult().getItemMeta() + " / data " + event.getRecipe().getResult().getData());
         if(!event.getRecipe().getResult().getType().equals(Material.FILLED_MAP)) {
             return;
         }

--- a/src/main/java/com/volmit/iris/core/service/VillageSVC.java
+++ b/src/main/java/com/volmit/iris/core/service/VillageSVC.java
@@ -43,11 +43,11 @@ public class VillageSVC implements IrisService {
      */
     @EventHandler
     public void on(VillagerAcquireTradeEvent event) {
-        if(!IrisToolbelt.isIrisWorld((event.getEntity().getWorld()))) {
+        if(!IrisToolbelt.isIrisWorld(event.getEntity().getWorld())) {
             return;
         }
 
-        // Iris.info("Trade event: type " + event.getRecipe().getResult().getType() + " / meta " + event.getRecipe().getResult().getItemMeta() + " / data " + event.getRecipe().getResult().getData());
+        Iris.info("Trade event: type " + event.getRecipe().getResult().getType() + " / meta " + event.getRecipe().getResult().getItemMeta() + " / data " + event.getRecipe().getResult().getData());
         if(!event.getRecipe().getResult().getType().equals(Material.FILLED_MAP)) {
             return;
         }

--- a/src/main/java/com/volmit/iris/engine/object/IrisDimension.java
+++ b/src/main/java/com/volmit/iris/engine/object/IrisDimension.java
@@ -223,8 +223,10 @@ public class IrisDimension extends IrisRegistrant {
     private IrisMaterialPalette rockPalette = new IrisMaterialPalette().qclear().qadd("stone");
     @Desc("The palette of blocks for 'water'")
     private IrisMaterialPalette fluidPalette = new IrisMaterialPalette().qclear().qadd("water");
-    @Desc("Cartographer map trade overrides")
-    private IrisVillagerOverride patchCartographers = new IrisVillagerOverride().setDisableTrade(false);
+//    @Desc("Cartographer map trade overrides")
+//    private IrisVillagerOverride patchCartographers = new IrisVillagerOverride().setDisableTrade(false);
+    @Desc("Remove cartographers so they do not crash the server (Iris worlds only)")
+    private boolean removeCartographersDueToCrash = true;
     @Desc("Collection of ores to be generated")
     @ArrayType(type = IrisOreGenerator.class, min = 1)
     private KList<IrisOreGenerator> ores = new KList<>();

--- a/src/main/java/com/volmit/iris/engine/object/IrisDimension.java
+++ b/src/main/java/com/volmit/iris/engine/object/IrisDimension.java
@@ -227,6 +227,8 @@ public class IrisDimension extends IrisRegistrant {
 //    private IrisVillagerOverride patchCartographers = new IrisVillagerOverride().setDisableTrade(false);
     @Desc("Remove cartographers so they do not crash the server (Iris worlds only)")
     private boolean removeCartographersDueToCrash = true;
+    @Desc("Notify players of cancelled cartographer villager in this radius in blocks (set to -1 to disable, -2 for everyone)")
+    private int notifyPlayersOfCartographerCancelledRadius = 30;
     @Desc("Collection of ores to be generated")
     @ArrayType(type = IrisOreGenerator.class, min = 1)
     private KList<IrisOreGenerator> ores = new KList<>();


### PR DESCRIPTION
Minecraft 1.18 decided it would be a good idea to make the custom world maps that cartographers let you buy BEFORE THE FUCKING EVENT TRIGGERS
so it kills the server every time a cartographer villager levels up, and there is NOTHING we can do about it.
So now, I just cancelled the event of when a villager becomes a cartographer and let everyone in a 30 block radius know by means of a chat message.