### PR TITLE
"Default" IrisDimension instead of "Overworld"

### DIFF
--- a/src/main/java/com/volmit/iris/core/commands/CommandIris.java
+++ b/src/main/java/com/volmit/iris/core/commands/CommandIris.java
@@ -60,7 +60,7 @@ public class CommandIris implements DecreeExecutor {
     public void create(
         @Param(aliases = "world-name", description = "The name of the world to create")
             String name,
-        @Param(aliases = "dimension", description = "The dimension type to create the world with", defaultValue = "overworld")
+        @Param(aliases = "dimension", description = "The dimension type to create the world with", defaultValue = "default")
             IrisDimension type,
         @Param(description = "The seed to generate the world with", defaultValue = "1337")
             long seed

--- a/src/main/java/com/volmit/iris/core/commands/CommandStudio.java
+++ b/src/main/java/com/volmit/iris/core/commands/CommandStudio.java
@@ -121,7 +121,7 @@ public class CommandStudio implements DecreeExecutor {
 
     @Decree(description = "Open a new studio world", aliases = "o", sync = true)
     public void open(
-        @Param(defaultValue = "overworld", description = "The dimension to open a studio for", aliases = "dim")
+        @Param(defaultValue = "default", description = "The dimension to open a studio for", aliases = "dim")
             IrisDimension dimension,
         @Param(defaultValue = "1337", description = "The seed to generate the studio with", aliases = "s")
             long seed) {
@@ -131,7 +131,7 @@ public class CommandStudio implements DecreeExecutor {
 
     @Decree(description = "Open VSCode for a dimension", aliases = {"vsc", "edit"})
     public void vscode(
-        @Param(defaultValue = "overworld", description = "The dimension to open VSCode for", aliases = "dim")
+        @Param(defaultValue = "default", description = "The dimension to open VSCode for", aliases = "dim")
             IrisDimension dimension
     ) {
         sender().sendMessage(C.GREEN + "Opening VSCode for the \"" + dimension.getName() + "\" pack");
@@ -288,7 +288,7 @@ public class CommandStudio implements DecreeExecutor {
 
     @Decree(description = "Get the version of a pack")
     public void version(
-        @Param(defaultValue = "overworld", description = "The dimension get the version of", aliases = "dim", contextual = true)
+        @Param(defaultValue = "default", description = "The dimension get the version of", aliases = "dim", contextual = true)
             IrisDimension dimension
     ) {
         sender().sendMessage(C.GREEN + "The \"" + dimension.getName() + "\" pack has version: " + dimension.getVersion());
@@ -417,7 +417,7 @@ public class CommandStudio implements DecreeExecutor {
 
     @Decree(description = "Package a dimension into a compressed format", aliases = "package")
     public void pkg(
-        @Param(name = "dimension", description = "The dimension pack to compress", contextual = true, defaultValue = "overworld")
+        @Param(name = "dimension", description = "The dimension pack to compress", contextual = true, defaultValue = "default")
             IrisDimension dimension,
         @Param(name = "obfuscate", description = "Whether or not to obfuscate the pack", defaultValue = "false")
             boolean obfuscate,
@@ -429,7 +429,7 @@ public class CommandStudio implements DecreeExecutor {
 
     @Decree(description = "Profiles the performance of a dimension", origin = DecreeOrigin.PLAYER)
     public void profile(
-        @Param(description = "The dimension to profile", contextual = true, defaultValue = "overworld")
+        @Param(description = "The dimension to profile", contextual = true, defaultValue = "default")
             IrisDimension dimension
     ) {
         File pack = dimension.getLoadFile().getParentFile().getParentFile();
@@ -650,7 +650,7 @@ public class CommandStudio implements DecreeExecutor {
 
     @Decree(description = "Update your dimension projects VSCode workspace")
     public void update(
-        @Param(description = "The dimension to update the workspace of", contextual = true, defaultValue = "overworld")
+        @Param(description = "The dimension to update the workspace of", contextual = true, defaultValue = "default")
             IrisDimension dimension
     ) {
         sender().sendMessage(C.GOLD + "Updating Code Workspace for " + dimension.getName() + "...");

--- a/src/main/java/com/volmit/iris/util/decree/handlers/DimensionHandler.java
+++ b/src/main/java/com/volmit/iris/util/decree/handlers/DimensionHandler.java
@@ -19,6 +19,7 @@
 package com.volmit.iris.util.decree.handlers;
 
 import com.volmit.iris.Iris;
+import com.volmit.iris.core.IrisSettings;
 import com.volmit.iris.core.loader.IrisData;
 import com.volmit.iris.engine.object.IrisDimension;
 import com.volmit.iris.util.collection.KList;
@@ -56,13 +57,19 @@ public class DimensionHandler implements DecreeParameterHandler<IrisDimension> {
 
     @Override
     public IrisDimension parse(String in, boolean force) throws DecreeParsingException {
+
+        if(in.equalsIgnoreCase("default")) {
+            return parse(IrisSettings.get().getGenerator().getDefaultWorldType());
+        }
+
         KList<IrisDimension> options = getPossibilities(in);
+
 
         if(options.isEmpty()) {
             throw new DecreeParsingException("Unable to find Dimension \"" + in + "\"");
         }
         try {
-            return options.stream().filter((i) -> toString(i).equalsIgnoreCase(in)).collect(Collectors.toList()).get(0);
+            return options.stream().filter((i) -> toString(i).equalsIgnoreCase(in)).toList().get(0);
         } catch(Throwable e) {
             throw new DecreeParsingException("Unable to filter which Biome \"" + in + "\"");
         }


### PR DESCRIPTION
Allows the use of the defaultValue string for Decree commands to be "default" and hence allow the use of the actually configured default pack in the settings.config