### PR TITLE
Development update 2.2.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ plugins {
     id "de.undercouch.download" version "5.0.1"
 }
 
-version '2.2.1-1.19' // Needs to be version specific
+version '2.2.2-1.19' // Needs to be version specific
 def nmsVersion = "1.19"
 def apiVersion = '1.19'
 def spigotJarVersion = '1.19-R0.1-SNAPSHOT'

--- a/src/main/java/com/volmit/iris/Iris.java
+++ b/src/main/java/com/volmit/iris/Iris.java
@@ -85,7 +85,11 @@ import java.util.Objects;
 
 @SuppressWarnings("CanBeFinal")
 public class Iris extends VolmitPlugin implements Listener {
+
+    public static final String OVERWORLD_TAG = "2086";
+
     private static final Queue<Runnable> syncJobs = new ShurikenQueue<>();
+
     public static Iris instance;
     public static BukkitAudiences audiences;
     public static MultiverseCoreLink linkMultiverseCore;

--- a/src/main/java/com/volmit/iris/core/commands/CommandIris.java
+++ b/src/main/java/com/volmit/iris/core/commands/CommandIris.java
@@ -170,9 +170,13 @@ public class CommandIris implements DecreeExecutor {
         @Param(name = "overwrite", description = "Whether or not to overwrite the pack with the downloaded one", aliases = "force", defaultValue = "false")
             boolean overwrite
     ) {
-        branch = pack.equals("overworld") ? "stable" : branch;
         sender().sendMessage(C.GREEN + "Downloading pack: " + pack + "/" + branch + (trim ? " trimmed" : "") + (overwrite ? " overwriting" : ""));
-        Iris.service(StudioSVC.class).downloadSearch(sender(), "IrisDimensions/" + pack + "/" + branch, trim, overwrite);
+        if(pack.equals("overworld")) {
+            String url = "https://github.com/IrisDimensions/overworld/releases/download/" + Iris.OVERWORLD_TAG + "/overworld.zip";
+            Iris.service(StudioSVC.class).downloadRelease(sender(), url, trim, overwrite);
+        } else {
+            Iris.service(StudioSVC.class).downloadSearch(sender(), "IrisDimensions/" + pack + "/" + branch, trim, overwrite);
+        }
     }
 
     @Decree(description = "Get metrics for your world", aliases = "measure", origin = DecreeOrigin.PLAYER)

--- a/src/main/java/com/volmit/iris/core/link/IrisPapiExpansion.java
+++ b/src/main/java/com/volmit/iris/core/link/IrisPapiExpansion.java
@@ -20,6 +20,7 @@ package com.volmit.iris.core.link;
 
 import com.volmit.iris.Iris;
 import com.volmit.iris.core.tools.IrisToolbelt;
+import com.volmit.iris.engine.object.IrisBiome;
 import com.volmit.iris.engine.platform.PlatformChunkGenerator;
 import me.clip.placeholderapi.expansion.PlaceholderExpansion;
 import org.bukkit.Location;
@@ -59,15 +60,15 @@ public class IrisPapiExpansion extends PlaceholderExpansion {
 
         if(p.equalsIgnoreCase("biome_name")) {
             if(a != null) {
-                return a.getEngine().getBiome(l).getName();
+                return getBiome(a, l).getName();
             }
         } else if(p.equalsIgnoreCase("biome_id")) {
             if(a != null) {
-                return a.getEngine().getBiome(l).getLoadKey();
+                return getBiome(a, l).getLoadKey();
             }
         } else if(p.equalsIgnoreCase("biome_file")) {
             if(a != null) {
-                return a.getEngine().getBiome(l).getLoadFile().getPath();
+                return getBiome(a, l).getLoadFile().getPath();
             }
         } else if(p.equalsIgnoreCase("region_name")) {
             if(a != null) {
@@ -106,5 +107,9 @@ public class IrisPapiExpansion extends PlaceholderExpansion {
         }
 
         return null;
+    }
+
+    private IrisBiome getBiome(PlatformChunkGenerator a, Location l) {
+        return a.getEngine().getBiome(l.getBlockX(), l.getBlockY() - l.getWorld().getMinHeight(), l.getBlockZ());
     }
 }

--- a/src/main/java/com/volmit/iris/core/service/StudioSVC.java
+++ b/src/main/java/com/volmit/iris/core/service/StudioSVC.java
@@ -171,7 +171,7 @@ public class StudioSVC implements IrisService {
             String[] nodes = url.split("\\Q/\\E");
             String repo = nodes.length == 1 ? "IrisDimensions/" + nodes[0] : nodes[0] + "/" + nodes[1];
             branch = nodes.length > 2 ? nodes[2] : branch;
-            download(sender, repo, branch, trim, forceOverwrite);
+            download(sender, repo, branch, trim, forceOverwrite, false);
         } catch(Throwable e) {
             Iris.reportError(e);
             e.printStackTrace();
@@ -179,12 +179,22 @@ public class StudioSVC implements IrisService {
         }
     }
 
-    public void download(VolmitSender sender, String repo, String branch, boolean trim) throws JsonSyntaxException, IOException {
-        download(sender, repo, branch, trim, false);
+    public void downloadRelease(VolmitSender sender, String url, boolean trim, boolean forceOverwrite) {
+        try {
+            download(sender, "IrisDimensions", url, trim, forceOverwrite, true);
+        } catch(Throwable e) {
+            Iris.reportError(e);
+            e.printStackTrace();
+            sender.sendMessage("Failed to download 'IrisDimensions/overworld' from " + url + ".");
+        }
     }
 
-    public void download(VolmitSender sender, String repo, String branch, boolean trim, boolean forceOverwrite) throws JsonSyntaxException, IOException {
-        String url = "https://codeload.github.com/" + repo + "/zip/refs/heads/" + branch;
+    public void download(VolmitSender sender, String repo, String branch, boolean trim) throws JsonSyntaxException, IOException {
+        download(sender, repo, branch, trim, false, false);
+    }
+
+    public void download(VolmitSender sender, String repo, String branch, boolean trim, boolean forceOverwrite, boolean directUrl) throws JsonSyntaxException, IOException {
+        String url = directUrl ? branch : "https://codeload.github.com/" + repo + "/zip/refs/heads/" + branch;
         sender.sendMessage("Downloading " + url + " "); //The extra space stops a bug in adventure API from repeating the last letter of the URL
         File zip = Iris.getNonCachedFile("pack-" + trim + "-" + repo, url);
         File temp = Iris.getTemp();

--- a/src/main/java/com/volmit/iris/core/tools/IrisCreator.java
+++ b/src/main/java/com/volmit/iris/core/tools/IrisCreator.java
@@ -38,8 +38,11 @@ import org.bukkit.GameRule;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.WorldCreator;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.YamlConfiguration;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
@@ -174,7 +177,8 @@ public class IrisCreator {
                     world.get().setTime(6000);
                 }
             });
-        }
+        } else
+            addToBukkitYml();
 
         if(pregen != null) {
             CompletableFuture<Boolean> ff = new CompletableFuture<>();
@@ -204,7 +208,24 @@ public class IrisCreator {
                 e.printStackTrace();
             }
         }
-
         return world.get();
+    }
+
+    private static final File BUKKIT_YML = new File(Bukkit.getServer().getWorldContainer(), "bukkit.yml");
+
+    private void addToBukkitYml() {
+        YamlConfiguration yml = YamlConfiguration.loadConfiguration(BUKKIT_YML);
+        String gen = "Iris:" + dimension;
+        ConfigurationSection section = yml.contains("worlds") ? yml.getConfigurationSection("worlds") : yml.createSection("worlds");
+        if(!section.contains(name)) {
+            section.createSection(name).set("generator", gen);
+            try {
+                yml.save(BUKKIT_YML);
+                Iris.info("Registered \"" + name + "\" in bukkit.yml");
+            } catch(IOException e) {
+                Iris.error("Failed to update bukkit.yml!");
+                e.printStackTrace();
+            }
+        }
     }
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -2,7 +2,7 @@ name: ${name}
 version: ${version}
 main: ${main}
 load: STARTUP
-authors: [ cyberpwn, NextdoorPsycho ]
+authors: [ cyberpwn, NextdoorPsycho. Vatuu ]
 website: volmit.com
 description: More than a Dimension!
 libraries:
@@ -22,4 +22,4 @@ commands:
     aliases: [ ir, irs ]
 api-version: ${apiversion}
 hotload-dependencies: false
-softdepend: [ "Oraxen", "ItemsAdder", "IrisFeller", "WorldEdit"]
+softdepend: [ "Oraxen", "ItemsAdder", "IrisFeller", "WorldEdit", "PlaceholderAPI"]


### PR DESCRIPTION
Changelog:
- /iris create now puts the world in Bukkit.yml
- PAPE should be working now
- The iris jars from THIS POINT FORWARD, will use the RELEASES as the primary version,  for pack download, to prevent the deprecation of the jars / pack issues when we update from version to version. (saves everyone some headache)
- Happy 2.2.2, next up 3.3.3!