### PR TITLE
Do not use "i" in the Iris commands

### DIFF
--- a/src/main/java/com/volmit/iris/core/commands/CommandIris.java
+++ b/src/main/java/com/volmit/iris/core/commands/CommandIris.java
@@ -45,7 +45,7 @@ import java.io.File;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
-@Decree(name = "iris", aliases = {"ir", "irs", "i"}, description = "Basic Command")
+@Decree(name = "iris", aliases = {"ir", "irs"}, description = "Basic Command")
 public class CommandIris implements DecreeExecutor {
     private CommandStudio studio;
     private CommandPregen pregen;
@@ -105,12 +105,6 @@ public class CommandIris implements DecreeExecutor {
     public void height() {
         sender().sendMessage(C.GREEN + "" + sender().player().getWorld().getMinHeight() + " to " + sender().player().getWorld().getMaxHeight());
         sender().sendMessage(C.GREEN + "Total Height: " + (sender().player().getWorld().getMaxHeight() - sender().player().getWorld().getMinHeight()));
-    }
-
-    @Decree(description = "QOL command to open a overworld studio world.")
-    public void so() {
-        sender().sendMessage(C.GREEN + "Opening studio for the \"Overworld\" pack (seed: 1337)");
-        Iris.service(StudioSVC.class).open(sender(), 1337, "overworld");
     }
 
     @Decree(description = "Set aura spins")

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -19,7 +19,7 @@ libraries:
   - bsf:bsf:2.4.0
 commands:
   iris:
-    aliases: [ ir, irs, i ]
+    aliases: [ ir, irs ]
 api-version: ${apiversion}
 hotload-dependencies: false
 softdepend: [ "Oraxen", "ItemsAdder", "IrisFeller", "WorldEdit", "PlaceholderAPI"]


### PR DESCRIPTION
Reasoning being that since many server owners use the plugin Essentials, they will be familiar with the /i command to give themselves items. Many server admins, including myself use this command very regularly.
While we (Iris) may find it easier to have the shorthand, the people used to using the command to give themselves Items will understandably be confused when the command leads to Iris. I recommend not adding this shorthand because of that. /ir is short enough.
Also, /ir s o opens the studio world, the extra space between the s and o isn't worth making a new command over imo.