### PR TITLE
Development

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ plugins {
     id "de.undercouch.download" version "5.0.1"
 }
 
-version '2.2.6-1.19.1' // Needs to be version specific
+version '2.2.7-1.19.1' // Needs to be version specific
 def nmsVersion = "1.19.1"
 def apiVersion = '1.19'
 def spigotJarVersion = '1.19.1-R0.1-SNAPSHOT'

--- a/src/main/java/com/volmit/iris/core/gui/NoiseExplorerGUI.java
+++ b/src/main/java/com/volmit/iris/core/gui/NoiseExplorerGUI.java
@@ -148,7 +148,7 @@ public class NoiseExplorerGUI extends JPanel implements MouseWheelListener, List
         JFrame frame = new JFrame("Noise Explorer");
         NoiseExplorerGUI nv = new NoiseExplorerGUI();
         frame.setDefaultCloseOperation(JFrame.HIDE_ON_CLOSE);
-        KList<String> li = new KList<>(NoiseStyle.values()).toStringList();
+        KList<String> li = new KList<>(NoiseStyle.values()).toStringList().sort();
         combo = new JComboBox<>(li.toArray(new String[0]));
         combo.setSelectedItem("STATIC");
         combo.setFocusable(false);

--- a/src/main/java/com/volmit/iris/core/pregenerator/IrisPregenerator.java
+++ b/src/main/java/com/volmit/iris/core/pregenerator/IrisPregenerator.java
@@ -140,6 +140,7 @@ public class IrisPregenerator {
         generator.close();
         ticker.interrupt();
         listener.onClose();
+        getMantle().trim(0);
     }
 
     private void visitRegion(int x, int z, boolean regions) {


### PR DESCRIPTION
**Changelog:**
"_Originally, the pregen job was periodically cleaning the mantle region cache upon entering each new region But that clean only takes out regions that have not been accessed for a certain period of time So while the pregen went on, it just never removed older regions as they were continuously accessed by validation_" ~ Vatuu
- Fixed a Memory creeping then crashing by cleaning old regions
- Sorted Noise Values in noise maps.