### PR TITLE
Development

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,8 +24,8 @@ plugins {
     id "de.undercouch.download" version "5.0.1"
 }
 
-version '2.2.7-1.19.1' // Needs to be version specific
-def nmsVersion = "1.19.1"
+version '2.2.8-1.19.2' // Needs to be version specific
+def nmsVersion = "1.19.2"
 def apiVersion = '1.19'
 def spigotJarVersion = '1.19.1-R0.1-SNAPSHOT'
 def name = getRootProject().getName() // Defined in settings.gradle

--- a/src/main/java/com/volmit/iris/core/nms/INMS.java
+++ b/src/main/java/com/volmit/iris/core/nms/INMS.java
@@ -20,7 +20,7 @@ package com.volmit.iris.core.nms;
 
 import com.volmit.iris.Iris;
 import com.volmit.iris.core.IrisSettings;
-import com.volmit.iris.core.nms.v19_1.NMSBinding19_1;
+import com.volmit.iris.core.nms.v19_2.NMSBinding19_2;
 import com.volmit.iris.core.nms.v1X.NMSBinding1X;
 import com.volmit.iris.util.collection.KMap;
 import org.bukkit.Bukkit;
@@ -28,7 +28,7 @@ import org.bukkit.Bukkit;
 public class INMS {
     //@builder
     private static final KMap<String, Class<? extends INMSBinding>> bindings = new KMap<String, Class<? extends INMSBinding>>()
-        .qput("v1_19_R1", NMSBinding19_1.class);
+        .qput("v1_19_R1", NMSBinding19_2.class);
     //@done
     private static final INMSBinding binding = bind();
 

--- a/src/main/java/com/volmit/iris/core/nms/v19_2/NMSBinding19_2.java
+++ b/src/main/java/com/volmit/iris/core/nms/v19_2/NMSBinding19_2.java
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package com.volmit.iris.core.nms.v19_1;
+package com.volmit.iris.core.nms.v19_2;
 
 
 import com.volmit.iris.Iris;
@@ -39,15 +39,10 @@ import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import net.minecraft.core.*;
 import net.minecraft.nbt.NbtIo;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.util.BitStorage;
-import net.minecraft.util.Mth;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.chunk.ChunkAccess;
-import net.minecraft.world.level.chunk.LevelChunkSection;
-import net.minecraft.world.level.chunk.Palette;
-import net.minecraft.world.level.chunk.PalettedContainer;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -74,7 +69,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
-public class NMSBinding19_1 implements INMSBinding {
+public class NMSBinding19_2 implements INMSBinding {
 
     private final KMap<Biome, Object> baseBiomeCache = new KMap<>();
     private final BlockData AIR = Material.AIR.createBlockData();

--- a/src/main/java/com/volmit/iris/engine/mode/ModeOverworld.java
+++ b/src/main/java/com/volmit/iris/engine/mode/ModeOverworld.java
@@ -42,10 +42,10 @@ public class ModeOverworld extends IrisEngineMode implements EngineMode {
         var deposit = new IrisDepositModifier(getEngine());
         var perfection = new IrisPerfectionModifier(getEngine());
 
+        registerStage((x, z, k, p, m) -> biome.actuate(x, z, p, m));
         registerStage(burst(
             (x, z, k, p, m) -> generateMatter(x >> 4, z >> 4, m),
-            (x, z, k, p, m) -> terrain.actuate(x, z, k, m),
-            (x, z, k, p, m) -> biome.actuate(x, z, p, m)
+            (x, z, k, p, m) -> terrain.actuate(x, z, k, m)
         ));
         registerStage((x, z, k, p, m) -> cave.modify(x >> 4, z >> 4, k, m));
         registerStage((x, z, k, p, m) -> deposit.modify(x, z, k, m));


### PR DESCRIPTION
Changelog:

- updated the NMS to support 1.19.2
- Added Semaphores to the generation to slow down the rate iris Queues chunks in the Pregenerator
- Added a limit to max being your CPU core count instead of infinite. 
Performance gain may or may not be here, as the performance is negligible at best, but its a change for the future generation to rely on for caching