### PR TITLE
Development

### DIFF
--- a/src/main/java/com/volmit/iris/engine/object/IrisObject.java
+++ b/src/main/java/com/volmit/iris/engine/object/IrisObject.java
@@ -781,7 +781,7 @@ public class IrisObject extends IrisRegistrant {
                     zz += config.warp(rng, i.getZ() + z, i.getY() + y, i.getX() + x, getLoader());
                 }
 
-                if(yv < 0 && (config.getMode().equals(ObjectPlaceMode.PAINT))) {
+                if(yv < 0 && (config.getMode().equals(ObjectPlaceMode.PAINT)) && !B.isVineBlock(data)) {
                     yy = (int) Math.round(i.getY()) + Math.floorDiv(h, 2) + placer.getHighest(xx, zz, getLoader(), config.isUnderwater());
                 }
 
@@ -823,7 +823,9 @@ public class IrisObject extends IrisRegistrant {
                     placer.getEngine().getMantle().getMantle().set(xx, yy, zz, new MatterMarker(markers.get(g)));
                 }
 
-                if(!data.getMaterial().equals(Material.AIR) && !data.getMaterial().equals(Material.CAVE_AIR)) {
+                boolean wouldReplace = B.isSolid(placer.get(xx, yy, zz)) && B.isVineBlock(data);
+
+                if(!data.getMaterial().equals(Material.AIR) && !data.getMaterial().equals(Material.CAVE_AIR) && !wouldReplace) {
                     placer.set(xx, yy, zz, data);
                     if(tile != null) {
                         placer.setTile(xx, yy, zz, tile);

--- a/src/main/java/com/volmit/iris/engine/platform/BukkitChunkGenerator.java
+++ b/src/main/java/com/volmit/iris/engine/platform/BukkitChunkGenerator.java
@@ -81,12 +81,14 @@ public class BukkitChunkGenerator extends ChunkGenerator implements PlatformChun
     private Engine engine;
     private Looper hotloader;
     private StudioMode lastMode;
+    private DummyBiomeProvider dummyBiomeProvider;
     @Setter
     private StudioGenerator studioGenerator;
 
     public BukkitChunkGenerator(IrisWorld world, boolean studio, File dataLocation, String dimensionKey) {
         setup = new AtomicBoolean(false);
         studioGenerator = null;
+        dummyBiomeProvider = new DummyBiomeProvider();
         populators = new KList<>();
         loadLock = new Semaphore(LOAD_LOCKS);
         this.world = world;
@@ -368,6 +370,6 @@ public class BukkitChunkGenerator extends ChunkGenerator implements PlatformChun
     @Nullable
     @Override
     public BiomeProvider getDefaultBiomeProvider(@NotNull WorldInfo worldInfo) {
-        return null;
+        return dummyBiomeProvider;
     }
 }

--- a/src/main/java/com/volmit/iris/engine/platform/DummyBiomeProvider.java
+++ b/src/main/java/com/volmit/iris/engine/platform/DummyBiomeProvider.java
@@ -1,5 +1,6 @@
 package com.volmit.iris.engine.platform;
 
+import com.volmit.iris.util.collection.KList;
 import org.bukkit.block.Biome;
 import org.bukkit.generator.BiomeProvider;
 import org.bukkit.generator.WorldInfo;
@@ -8,7 +9,7 @@ import org.jetbrains.annotations.NotNull;
 import java.util.List;
 
 public class DummyBiomeProvider extends BiomeProvider {
-    private final List<Biome> ALL = List.of(Biome.values());
+    private final List<Biome> ALL = new KList<>(Biome.values()).qdel(Biome.CUSTOM);
 
     @NotNull
     @Override

--- a/src/main/java/com/volmit/iris/engine/platform/DummyBiomeProvider.java
+++ b/src/main/java/com/volmit/iris/engine/platform/DummyBiomeProvider.java
@@ -1,0 +1,24 @@
+package com.volmit.iris.engine.platform;
+
+import org.bukkit.block.Biome;
+import org.bukkit.generator.BiomeProvider;
+import org.bukkit.generator.WorldInfo;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+public class DummyBiomeProvider extends BiomeProvider {
+    private final List<Biome> ALL = List.of(Biome.values());
+
+    @NotNull
+    @Override
+    public Biome getBiome(@NotNull WorldInfo worldInfo, int x, int y, int z) {
+        return Biome.PLAINS;
+    }
+
+    @NotNull
+    @Override
+    public List<Biome> getBiomes(@NotNull WorldInfo worldInfo) {
+        return ALL;
+    }
+}

--- a/src/main/java/com/volmit/iris/util/data/B.java
+++ b/src/main/java/com/volmit/iris/util/data/B.java
@@ -405,6 +405,8 @@ public class B {
     }
 
     public static boolean isSolid(BlockData mat) {
+        if(mat == null)
+            return false;
         return mat.getMaterial().isSolid();
     }
 

--- a/src/main/java/com/volmit/iris/util/stream/ProceduralStream.java
+++ b/src/main/java/com/volmit/iris/util/stream/ProceduralStream.java
@@ -20,6 +20,7 @@ package com.volmit.iris.util.stream;
 
 import com.volmit.iris.Iris;
 import com.volmit.iris.core.loader.IrisData;
+import com.volmit.iris.engine.data.cache.Cache;
 import com.volmit.iris.engine.framework.Engine;
 import com.volmit.iris.engine.object.IRare;
 import com.volmit.iris.engine.object.IrisStyledRange;
@@ -530,6 +531,21 @@ public interface ProceduralStream<T> extends ProceduralLayer, Interpolated<T> {
     ProceduralStream<T> getTypedSource();
 
     ProceduralStream<?> getSource();
+
+    default void fillChunk(int x, int z, T[] c) {
+        if(c.length != 256) {
+            throw new RuntimeException("Not 256 Length for chunk get");
+        }
+
+        int xs = x << 4;
+        int zs = z << 4;
+
+        for(int i = 0; i < 16; i++) {
+            for(int j = 0; j < 16; j++) {
+                c[Cache.to1D(i+xs, j+zs, 0, 16, 16)] = get(i+xs, j+zs);
+            }
+        }
+    }
 
     T get(double x, double z);
 


### PR DESCRIPTION
Changelog:

- Improved Generator Generation Performance 5-20%  _(We disabled the vanilla biome setter because it was doing CUBIC SPLINE CALCULATIONS for whatever reason, and disabling that is an experimental fix at this problem as we continue to improve the generation speeds. you will notice a speed bonus :) )_
- Made a Dummy Biome provider to skip Banilla (Speed up custom chunks)
- Limited the number of spammed threads, should reduce memory consumption and fic Crash on docker
- Improved Skulk, and general Vine placements when using paint (Need more feedback)