### PR TITLE
fix issue with `bukkit.yml` world-container option

### DIFF
--- a/src/main/java/com/volmit/iris/Iris.java
+++ b/src/main/java/com/volmit/iris/Iris.java
@@ -684,7 +684,7 @@ public class Iris extends VolmitPlugin implements Listener {
                 .name(worldName)
                 .seed(1337)
                 .environment(dim.getEnvironment())
-                .worldFolder(new File(worldName))
+                .worldFolder(new File(Bukkit.getWorldContainer(), worldName))
                 .minHeight(dim.getMinHeight())
                 .maxHeight(dim.getMaxHeight())
                 .build();

--- a/src/main/java/com/volmit/iris/core/ServerConfigurator.java
+++ b/src/main/java/com/volmit/iris/core/ServerConfigurator.java
@@ -84,7 +84,7 @@ public class ServerConfigurator {
 
     private static List<File> getDatapacksFolder() {
         if (!IrisSettings.get().getGeneral().forceMainWorld.isEmpty()) {
-            return new KList<File>().qadd(new File(IrisSettings.get().getGeneral().forceMainWorld + "/datapacks"));
+            return new KList<File>().qadd(new File(Bukkit.getWorldContainer(), IrisSettings.get().getGeneral().forceMainWorld + "/datapacks"));
         }
         KList<File> worlds = new KList<>();
         Bukkit.getServer().getWorlds().forEach(w -> worlds.add(new File(w.getWorldFolder(), "datapacks")));

--- a/src/main/java/com/volmit/iris/core/commands/CommandIris.java
+++ b/src/main/java/com/volmit/iris/core/commands/CommandIris.java
@@ -73,7 +73,7 @@ public class CommandIris implements DecreeExecutor {
             return;
         }
 
-        if (new File(name).exists()) {
+        if (new File(Bukkit.getWorldContainer(), name).exists()) {
             sender().sendMessage(C.RED + "That folder already exists!");
             return;
         }

--- a/src/main/java/com/volmit/iris/core/tools/IrisCreator.java
+++ b/src/main/java/com/volmit/iris/core/tools/IrisCreator.java
@@ -51,7 +51,7 @@ import java.util.function.Supplier;
 @Data
 @Accessors(fluent = true, chain = true)
 public class IrisCreator {
-    private static final File BUKKIT_YML = new File(Bukkit.getServer().getWorldContainer(), "bukkit.yml");
+    private static final File BUKKIT_YML = new File("bukkit.yml");
     /**
      * Specify an area to pregenerate during creation
      */
@@ -115,7 +115,7 @@ public class IrisCreator {
             sender = Iris.getSender();
 
         if (!studio()) {
-            Iris.service(StudioSVC.class).installIntoWorld(sender, d.getLoadKey(), new File(name()));
+            Iris.service(StudioSVC.class).installIntoWorld(sender, d.getLoadKey(), new File(Bukkit.getWorldContainer(), name()));
         }
 
         PlatformChunkGenerator access = null;

--- a/src/main/java/com/volmit/iris/core/tools/IrisWorldCreator.java
+++ b/src/main/java/com/volmit/iris/core/tools/IrisWorldCreator.java
@@ -22,6 +22,7 @@ import com.volmit.iris.core.loader.IrisData;
 import com.volmit.iris.engine.object.IrisDimension;
 import com.volmit.iris.engine.object.IrisWorld;
 import com.volmit.iris.engine.platform.BukkitChunkGenerator;
+import org.bukkit.Bukkit;
 import org.bukkit.World;
 import org.bukkit.WorldCreator;
 import org.bukkit.generator.ChunkGenerator;
@@ -71,7 +72,7 @@ public class IrisWorldCreator {
                 .minHeight(dim.getMinHeight())
                 .maxHeight(dim.getMaxHeight())
                 .seed(seed)
-                .worldFolder(new File(name))
+                .worldFolder(new File(Bukkit.getWorldContainer(), name))
                 .environment(findEnvironment())
                 .build();
         ChunkGenerator g = new BukkitChunkGenerator(w, studio, studio

--- a/src/main/java/com/volmit/iris/engine/object/IrisWorld.java
+++ b/src/main/java/com/volmit/iris/engine/object/IrisWorld.java
@@ -108,7 +108,7 @@ public class IrisWorld {
 
     public void bind(WorldInfo worldInfo) {
         name(worldInfo.getName())
-                .worldFolder(new File(worldInfo.getName()))
+                .worldFolder(new File(Bukkit.getWorldContainer(), worldInfo.getName()))
                 .minHeight(worldInfo.getMinHeight())
                 .maxHeight(worldInfo.getMaxHeight())
                 .environment(worldInfo.getEnvironment());


### PR DESCRIPTION
Iris is a wonderful plugin, I realy love it. Iris currently has some issues when [`world-container`](https://bukkit.fandom.com/wiki/Bukkit.yml#world-container) enabled, Suppose that `world-container: worlds` is set and a world named `test` is created.

1. `/iris create` creates a new `bukkit.yml` in *worlds/* instead of modifying the one in the *root directory*;
2. *iris/* and *mantle/* will be created under *test/* instead of *worlds/test/*. 

The worldfolder is not necessarily in the root directory (same level as `purpur.jar`). If  `world-container` is set in `bukkit.yml`, the world directory can place anywhere. This mechanism can make the file structure more clear (especially in the case of many worlds). In most cases, Iris gets the correct location of the world directory through `World.worldFolder()` and `Bukkit.getWorldContainer()`, but in some cases it does not. 

My PR attempts to fix these issues. I tested it on my server, and it seems to work correctly. However, I haven't read all the codes and in some cases it may not handled correctly (However, adding `Bukkit.getWorldContainer()` doesn't do anything when `world-container` is not set, so my PR does not break the plugin).