### PR TITLE
MM should set its own stuff

### DIFF
--- a/src/main/java/com/volmit/iris/engine/object/IrisEntity.java
+++ b/src/main/java/com/volmit/iris/engine/object/IrisEntity.java
@@ -154,6 +154,9 @@ public class IrisEntity extends IrisRegistrant {
     @Desc("Create a mob from another plugin, such as Mythic Mobs. Should be in the format of a namespace of PluginName:MobName")
     private String specialType = "";
 
+    @Desc("Set to true if you want to apply all of the settings here to the mob, even though an external plugin has already done so. Scripts are always applied.")
+    private boolean applySettingsToCustomMobAnyways = false;
+
     @Desc("Set the entity type to UNKNOWN, then define a script here which ends with the entity variable (the result). You can use Iris.getLocation() to find the target location. You can spawn any entity this way.")
     @RegistryListResource(IrisScript.class)
     private String spawnerScript = "";
@@ -209,6 +212,10 @@ public class IrisEntity extends IrisRegistrant {
                     ex.printStackTrace();
                 }
             }
+        }
+
+        if (isSpecialType() && !applySettingsToCustomMobAnyways) {
+            return ee;
         }
 
         if (ee == null) {
@@ -442,8 +449,7 @@ public class IrisEntity extends IrisRegistrant {
 
         if (isSpecialType()) {
             if (specialType.toLowerCase().startsWith("mythicmobs:")) {
-                Iris.linkMythicMobs.spawnMob(specialType.substring(11), at);
-                return null;
+                return Iris.linkMythicMobs.spawnMob(specialType.substring(11), at);
             } else {
                 Iris.warn("Invalid mob type to spawn: '" + specialType + "'!");
                 return null;

--- a/src/main/java/com/volmit/iris/engine/object/IrisEntity.java
+++ b/src/main/java/com/volmit/iris/engine/object/IrisEntity.java
@@ -442,7 +442,8 @@ public class IrisEntity extends IrisRegistrant {
 
         if (isSpecialType()) {
             if (specialType.toLowerCase().startsWith("mythicmobs:")) {
-                return Iris.linkMythicMobs.spawnMob(specialType.substring(11), at);
+                Iris.linkMythicMobs.spawnMob(specialType.substring(11), at);
+                return null;
             } else {
                 Iris.warn("Invalid mob type to spawn: '" + specialType + "'!");
                 return null;


### PR DESCRIPTION
By default stops Iris from applying its custom properties to `specialType` mobs.
Adds a setting to Entities, called `applySettingsToCustomMobAnyways` (false by default) which is used to apply the custom properties anyways.
Scripts apply always.