### PR TITLE
Implements slope rotation

### DIFF
--- a/src/main/java/com/volmit/iris/engine/object/IrisObject.java
+++ b/src/main/java/com/volmit/iris/engine/object/IrisObject.java
@@ -30,10 +30,7 @@ import com.volmit.iris.util.data.B;
 import com.volmit.iris.util.format.Form;
 import com.volmit.iris.util.interpolation.IrisInterpolation;
 import com.volmit.iris.util.json.JSONObject;
-import com.volmit.iris.util.math.AxisAlignedBB;
-import com.volmit.iris.util.math.BlockPosition;
-import com.volmit.iris.util.math.Position2;
-import com.volmit.iris.util.math.RNG;
+import com.volmit.iris.util.math.*;
 import com.volmit.iris.util.matter.MatterMarker;
 import com.volmit.iris.util.parallel.BurstExecutor;
 import com.volmit.iris.util.parallel.MultiBurst;
@@ -500,18 +497,11 @@ public class IrisObject extends IrisRegistrant {
         // Rotation calculation
         double slopeRotationY = 0;
         ProceduralStream<Double> heightStream = rdata.getEngine().getComplex().getHeightStream();
-        if (config.isRotateTowardsSlopePrecise()) {
-            // I take three points which together make a plane that decently represents the slope beneath the object
-            double hNorth = heightStream.get(x, z + ((float)h) / 2);
-            double hEast = heightStream.get(x + ((float)w) / 2, z);
-            double hSouthWest = heightStream.get(x - ((float)w) / 2, z - ((float)h) / 2);
-            // TODO: Complex math
-        } else if (config.isRotateTowardsSlope()) {
-            // TODO: Make this respect object rotation. Currently takes the object without rotation to define the corner points.
+        if (config.isRotateTowardsSlope()) {
             // Whichever side of the rectangle that bounds the object is lowest is the 'direction' of the slope (simply said).
-            double hNorth = heightStream.get(x, z + ((float)h) / 2);
+            double hNorth = heightStream.get(x, z + ((float)d) / 2);
             double hEast = heightStream.get(x + ((float)w) / 2, z);
-            double hSouth = heightStream.get(x, z - ((float)h) / 2);
+            double hSouth = heightStream.get(x, z - ((float)d) / 2);
             double hWest = heightStream.get(x - ((float)w) / 2, z);
             double min = Math.min(Math.min(hNorth, hEast), Math.min(hSouth, hWest));
             if (min == hNorth) {
@@ -524,6 +514,8 @@ public class IrisObject extends IrisRegistrant {
                 slopeRotationY = 270;
             }
         }
+        config.getRotation().setYAxis(new IrisAxisRotationClamp(true, false, slopeRotationY, slopeRotationY, 360));
+        config.getRotation().setEnabled(true);
 
         if (config.isSmartBore()) {
             ensureSmartBored(placer.isDebugSmartBore());

--- a/src/main/java/com/volmit/iris/engine/object/IrisObject.java
+++ b/src/main/java/com/volmit/iris/engine/object/IrisObject.java
@@ -500,7 +500,13 @@ public class IrisObject extends IrisRegistrant {
         // Rotation calculation
         double slopeRotationY = 0;
         ProceduralStream<Double> heightStream = rdata.getEngine().getComplex().getHeightStream();
-        if (config.isRotateTowardsSlope()) {
+        if (config.isRotateTowardsSlopePrecise()) {
+            // I take three points which together make a plane that decently represents the slope beneath the object
+            double hNorth = heightStream.get(x, z + ((float)h) / 2);
+            double hEast = heightStream.get(x + ((float)w) / 2, z);
+            double hSouthWest = heightStream.get(x - ((float)w) / 2, z - ((float)h) / 2);
+            // TODO: Complex math
+        } else if (config.isRotateTowardsSlope()) {
             // TODO: Make this respect object rotation (I have no idea how. So just make sure your objects are sort of square and you'll be fine)
             // Whichever side of the rectangle that bounds the object is lowest is the 'direction' of the slope (simply said).
             double hNorth = heightStream.get(x, z + ((float)h) / 2);
@@ -517,12 +523,6 @@ public class IrisObject extends IrisRegistrant {
             } else if (min == hWest) {
                 slopeRotationY = 270;
             }
-        } else if (config.isRotateTowardsSlopePrecise()) {
-            // I take three points which together make a plane that decently represents the slope beneath the object
-            double hNorth = heightStream.get(x, z + ((float)h) / 2);
-            double hEast = heightStream.get(x + ((float)w) / 2, z);
-            double hSouthWest = heightStream.get(x - ((float)w) / 2, z - ((float)h) / 2);
-            // TODO: Complex math
         }
 
         if (config.isSmartBore()) {

--- a/src/main/java/com/volmit/iris/engine/object/IrisObject.java
+++ b/src/main/java/com/volmit/iris/engine/object/IrisObject.java
@@ -503,6 +503,34 @@ public class IrisObject extends IrisRegistrant {
             return -1;
         }
 
+        // Rotation calculation
+        double slopeRotationY = 0;
+        ProceduralStream<Double> heightStream = rdata.getEngine().getComplex().getHeightStream();
+        if (config.isRotateTowardsSlope()) {
+            // TODO: Make this respect object rotation (I have no idea how. So just make sure your objects are sort of square and you'll be fine)
+            // Whichever side of the rectangle that bounds the object is lowest is the 'direction' of the slope (simply said).
+            double hNorth = heightStream.get(x, z + ((float)h) / 2);
+            double hEast = heightStream.get(x + ((float)w) / 2, z);
+            double hSouth = heightStream.get(x, z - ((float)h) / 2);
+            double hWest = heightStream.get(x - ((float)w) / 2, z);
+            double min = Math.min(Math.min(hNorth, hEast), Math.min(hSouth, hWest));
+            if (min == hNorth) {
+                slopeRotationY = 0;
+            } else if (min == hEast) {
+                slopeRotationY = 90;
+            } else if (min == hSouth) {
+                slopeRotationY = 180;
+            } else if (min == hWest) {
+                slopeRotationY = 270;
+            }
+        } else if (config.isRotateTowardsSlopePrecise()) {
+            // I take three points which together make a plane that decently represents the slope beneath the object
+            double hNorth = heightStream.get(x, z + ((float)h) / 2);
+            double hEast = heightStream.get(x + ((float)w) / 2, z);
+            double hSouthWest = heightStream.get(x - ((float)w) / 2, z - ((float)h) / 2);
+            // TODO: Complex math
+        }
+
         if (config.isSmartBore()) {
             ensureSmartBored(placer.isDebugSmartBore());
         }

--- a/src/main/java/com/volmit/iris/engine/object/IrisObject.java
+++ b/src/main/java/com/volmit/iris/engine/object/IrisObject.java
@@ -507,7 +507,7 @@ public class IrisObject extends IrisRegistrant {
             double hSouthWest = heightStream.get(x - ((float)w) / 2, z - ((float)h) / 2);
             // TODO: Complex math
         } else if (config.isRotateTowardsSlope()) {
-            // TODO: Make this respect object rotation (I have no idea how. So just make sure your objects are sort of square and you'll be fine)
+            // TODO: Make this respect object rotation. Currently takes the object without rotation to define the corner points.
             // Whichever side of the rectangle that bounds the object is lowest is the 'direction' of the slope (simply said).
             double hNorth = heightStream.get(x, z + ((float)h) / 2);
             double hEast = heightStream.get(x + ((float)w) / 2, z);

--- a/src/main/java/com/volmit/iris/engine/object/IrisObject.java
+++ b/src/main/java/com/volmit/iris/engine/object/IrisObject.java
@@ -497,13 +497,6 @@ public class IrisObject extends IrisRegistrant {
     public int place(int x, int yv, int z, IObjectPlacer oplacer, IrisObjectPlacement config, RNG rng, BiConsumer<BlockPosition, BlockData> listener, CarveResult c, IrisData rdata) {
         IObjectPlacer placer = (config.getHeightmap() != null) ? new HeightmapObjectPlacer(oplacer.getEngine() == null ? IrisContext.get().getEngine() : oplacer.getEngine(), rng, x, yv, z, config, oplacer) : oplacer;
 
-        // Slope calculation
-        if (!config.getSlopeCondition().isDefault() &&
-            !config.getSlopeCondition().isValid(rdata.getEngine().getComplex().getSlopeStream().get(x, z)))
-        {
-            return -1;
-        }
-
         // Rotation calculation
         double slopeRotationY = 0;
         ProceduralStream<Double> heightStream = rdata.getEngine().getComplex().getHeightStream();

--- a/src/main/java/com/volmit/iris/engine/object/IrisObject.java
+++ b/src/main/java/com/volmit/iris/engine/object/IrisObject.java
@@ -495,7 +495,7 @@ public class IrisObject extends IrisRegistrant {
         IObjectPlacer placer = (config.getHeightmap() != null) ? new HeightmapObjectPlacer(oplacer.getEngine() == null ? IrisContext.get().getEngine() : oplacer.getEngine(), rng, x, yv, z, config, oplacer) : oplacer;
 
         // Rotation calculation
-        double slopeRotationY = 0;
+        int slopeRotationY = 0;
         ProceduralStream<Double> heightStream = rdata.getEngine().getComplex().getHeightStream();
         if (config.isRotateTowardsSlope()) {
             // Whichever side of the rectangle that bounds the object is lowest is the 'direction' of the slope (simply said).
@@ -514,7 +514,8 @@ public class IrisObject extends IrisRegistrant {
                 slopeRotationY = 270;
             }
         }
-        config.getRotation().setYAxis(new IrisAxisRotationClamp(true, false, slopeRotationY, slopeRotationY, 360));
+        double newRotation = config.getRotation().getYAxis().getMin() + slopeRotationY;
+        config.getRotation().setYAxis(new IrisAxisRotationClamp(true, false, newRotation, newRotation, 360));
         config.getRotation().setEnabled(true);
 
         if (config.isSmartBore()) {

--- a/src/main/java/com/volmit/iris/engine/object/IrisObject.java
+++ b/src/main/java/com/volmit/iris/engine/object/IrisObject.java
@@ -496,6 +496,13 @@ public class IrisObject extends IrisRegistrant {
     public int place(int x, int yv, int z, IObjectPlacer oplacer, IrisObjectPlacement config, RNG rng, BiConsumer<BlockPosition, BlockData> listener, CarveResult c, IrisData rdata) {
         IObjectPlacer placer = (config.getHeightmap() != null) ? new HeightmapObjectPlacer(oplacer.getEngine() == null ? IrisContext.get().getEngine() : oplacer.getEngine(), rng, x, yv, z, config, oplacer) : oplacer;
 
+        // Slope calculation
+        if (!config.getSlopeCondition().isDefault() &&
+            !config.getSlopeCondition().isValid(rdata.getEngine().getComplex().getSlopeStream().get(x, z)))
+        {
+            return -1;
+        }
+
         if (config.isSmartBore()) {
             ensureSmartBored(placer.isDebugSmartBore());
         }

--- a/src/main/java/com/volmit/iris/engine/object/IrisObject.java
+++ b/src/main/java/com/volmit/iris/engine/object/IrisObject.java
@@ -40,6 +40,7 @@ import com.volmit.iris.util.parallel.MultiBurst;
 import com.volmit.iris.util.plugin.VolmitSender;
 import com.volmit.iris.util.scheduling.IrisLock;
 import com.volmit.iris.util.scheduling.PrecisionStopwatch;
+import com.volmit.iris.util.stream.ProceduralStream;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;

--- a/src/main/java/com/volmit/iris/engine/object/IrisObjectPlacement.java
+++ b/src/main/java/com/volmit/iris/engine/object/IrisObjectPlacement.java
@@ -64,6 +64,12 @@ public class IrisObjectPlacement {
     private boolean isDolphinTarget = false;
     @Desc("The slope at which this object can be placed. Range from 0 to 10 by default. Calculated from the corners of the object.")
     private IrisSlopeClip slopeCondition = new IrisSlopeClip();
+    @Desc("Set to true to add the rotation of the direction of the slope of the terrain (wherever the slope is going down) to the y-axis rotation of the object. See also rotateTowardsSlopePrecise.")
+    private boolean rotateTowardsSlope = false;
+    @Desc("By default the 'rotateTowardsSlope' function simply calculates which direction" +
+            " (North East South or West) is the lowest, resulting in a 0, 90, 180 or 270 degree rotations. " +
+            "Setting this to true does a precise calculation, which may give unwanted side-effects due to non-90 degree rotations.")
+    private boolean rotateTowardsSlopePrecise = false;
     @MinNumber(0)
     @MaxNumber(1)
     @Desc("The chance for this to place in a chunk. If you need multiple per chunk, set this to 1 and use density.")

--- a/src/main/java/com/volmit/iris/engine/object/IrisObjectPlacement.java
+++ b/src/main/java/com/volmit/iris/engine/object/IrisObjectPlacement.java
@@ -63,7 +63,7 @@ public class IrisObjectPlacement {
     @Desc("Whether or not this object can be targeted by a dolphin.")
     private boolean isDolphinTarget = false;
     @Desc("Set to true to add the rotation of the direction of the slope of the terrain (wherever the slope is going down) to the y-axis rotation of the object." +
-            "Overwrites the y-axis of the rotation settings if set to true, and force-enables it. This is rounded by 90 degrees as to not fuck up your objects.")
+            "Rounded to 90 degrees. Adds the *min* rotation of the y axis as well (to still allow you to rotate objects nicely). Discards *max* and *interval* on *yaxis*")
     private boolean rotateTowardsSlope = false;
     @MinNumber(0)
     @MaxNumber(1)

--- a/src/main/java/com/volmit/iris/engine/object/IrisObjectPlacement.java
+++ b/src/main/java/com/volmit/iris/engine/object/IrisObjectPlacement.java
@@ -62,6 +62,8 @@ public class IrisObjectPlacement {
     private double snow = 0;
     @Desc("Whether or not this object can be targeted by a dolphin.")
     private boolean isDolphinTarget = false;
+    @Desc("The slope at which this object can be placed. Range from 0 to 10 by default. Calculated from the corners of the object.")
+    private IrisSlopeClip slopeCondition = new IrisSlopeClip();
     @MinNumber(0)
     @MaxNumber(1)
     @Desc("The chance for this to place in a chunk. If you need multiple per chunk, set this to 1 and use density.")

--- a/src/main/java/com/volmit/iris/engine/object/IrisObjectPlacement.java
+++ b/src/main/java/com/volmit/iris/engine/object/IrisObjectPlacement.java
@@ -62,8 +62,6 @@ public class IrisObjectPlacement {
     private double snow = 0;
     @Desc("Whether or not this object can be targeted by a dolphin.")
     private boolean isDolphinTarget = false;
-    @Desc("The slope at which this object can be placed. Range from 0 to 10 by default. Calculated from the corners of the object.")
-    private IrisSlopeClip slopeCondition = new IrisSlopeClip();
     @Desc("Set to true to add the rotation of the direction of the slope of the terrain (wherever the slope is going down) to the y-axis rotation of the object. See also rotateTowardsSlopePrecise.")
     private boolean rotateTowardsSlope = false;
     @Desc("By default the 'rotateTowardsSlope' function simply calculates which direction" +

--- a/src/main/java/com/volmit/iris/engine/object/IrisObjectPlacement.java
+++ b/src/main/java/com/volmit/iris/engine/object/IrisObjectPlacement.java
@@ -62,12 +62,9 @@ public class IrisObjectPlacement {
     private double snow = 0;
     @Desc("Whether or not this object can be targeted by a dolphin.")
     private boolean isDolphinTarget = false;
-    @Desc("Set to true to add the rotation of the direction of the slope of the terrain (wherever the slope is going down) to the y-axis rotation of the object. See also rotateTowardsSlopePrecise.")
+    @Desc("Set to true to add the rotation of the direction of the slope of the terrain (wherever the slope is going down) to the y-axis rotation of the object." +
+            "Overwrites the y-axis of the rotation settings if set to true, and force-enables it. This is rounded by 90 degrees as to not fuck up your objects.")
     private boolean rotateTowardsSlope = false;
-    @Desc("By default the 'rotateTowardsSlope' function simply calculates which direction" +
-            " (North East South or West) is the lowest, resulting in a 0, 90, 180 or 270 degree rotations. " +
-            "Setting this to true does a precise calculation, which may give unwanted side-effects due to non-90 degree rotations.")
-    private boolean rotateTowardsSlopePrecise = false;
     @MinNumber(0)
     @MaxNumber(1)
     @Desc("The chance for this to place in a chunk. If you need multiple per chunk, set this to 1 and use density.")


### PR DESCRIPTION
Slope conditions allow one to prevent objects from being placed on too steep or too flat surfaces. This PR allows users to set a flag in the object's placement to true, to effectively rotate it in the direction where the slope is going down.