### PR TITLE
Replace continent renderer with biomeStream

### DIFF
--- a/src/main/java/com/volmit/iris/core/gui/components/IrisRenderer.java
+++ b/src/main/java/com/volmit/iris/core/gui/components/IrisRenderer.java
@@ -19,6 +19,8 @@
 package com.volmit.iris.core.gui.components;
 
 import com.volmit.iris.engine.framework.Engine;
+import com.volmit.iris.engine.object.IrisBiome;
+import com.volmit.iris.engine.object.IrisBiomeGeneratorLink;
 import com.volmit.iris.util.interpolation.IrisInterpolation;
 
 import java.awt.*;
@@ -50,12 +52,22 @@ public class IrisRenderer {
             case HEIGHT ->
                     colorFunction = (x, z) -> Color.getHSBColor(renderer.getComplex().getHeightStream().get(x, z).floatValue(), 100, 100).getRGB();
             case CONTINENT ->
-                    colorFunction = (x, z) -> (switch (renderer.getComplex().getBridgeStream().get(x, z)) {
-                        case SHORE -> Color.YELLOW;
-                        case LAND -> Color.GREEN;
-                        case SEA -> Color.BLUE;
-                        case CAVE -> Color.BLACK;
-                    }).getRGB();
+                    colorFunction = (x, z) -> {
+                        IrisBiome b = renderer.getBiome((int) Math.round(x), renderer.getMaxHeight() - 1, (int) Math.round(z));
+                        IrisBiomeGeneratorLink g = b.getGenerators().get(0);
+                        Color c;
+                        if (g.getMax() <= 0) {
+                            // Max is below water level, so it is most likely an ocean biome
+                            c = Color.BLUE;
+                        } else if (g.getMin() < 0) {
+                            // Min is below water level, but max is not, so it is most likely a shore biome
+                            c = Color.YELLOW;
+                        } else {
+                            // Both min and max are above water level, so it is most likely a land biome
+                            c = Color.GREEN;
+                        }
+                        return c.getRGB();
+                    };
         }
 
         double x, z;

--- a/src/main/java/com/volmit/iris/core/gui/components/IrisRenderer.java
+++ b/src/main/java/com/volmit/iris/core/gui/components/IrisRenderer.java
@@ -49,14 +49,13 @@ public class IrisRenderer {
                     colorFunction = (x, z) -> renderer.getComplex().getCaveBiomeStream().get(x, z).getColor(renderer, currentType).getRGB();
             case HEIGHT ->
                     colorFunction = (x, z) -> Color.getHSBColor(renderer.getComplex().getHeightStream().get(x, z).floatValue(), 100, 100).getRGB();
-            case CONTINENT -> {
-                double fluidHeight = renderer.getComplex().getFluidHeight();
-                int deltaHeight = renderer.getMaxHeight() - renderer.getMinHeight();
-                colorFunction = (x, z) -> {
-                    double h = renderer.getComplex().getHeightStream().get(x, z);
-                    return new Color((int) (h * 255d / deltaHeight), 128, h > fluidHeight ? 0 : 255).getRGB();
-                };
-            }
+            case CONTINENT ->
+                    colorFunction = (x, z) -> (switch (renderer.getComplex().getBridgeStream().get(x, z)) {
+                        case SHORE -> Color.YELLOW;
+                        case LAND -> Color.GREEN;
+                        case SEA -> Color.BLUE;
+                        case CAVE -> Color.BLACK;
+                    }).getRGB();
         }
 
         double x, z;

--- a/src/main/java/com/volmit/iris/engine/IrisComplex.java
+++ b/src/main/java/com/volmit/iris/engine/IrisComplex.java
@@ -220,7 +220,6 @@ public class IrisComplex implements DataProvider {
                 return seaBiomeStream;
             case SHORE:
                 return shoreBiomeStream;
-            case DEFER:
             default:
                 break;
         }

--- a/src/main/java/com/volmit/iris/engine/object/InferredType.java
+++ b/src/main/java/com/volmit/iris/engine/object/InferredType.java
@@ -32,8 +32,5 @@ public enum InferredType {
     SEA,
 
     @Desc("Represents any cave biome type")
-    CAVE,
-
-    @Desc("Defers the type to whatever another biome type that already exists is.")
-    DEFER
+    CAVE
 }

--- a/src/main/java/com/volmit/iris/engine/object/IrisBiome.java
+++ b/src/main/java/com/volmit/iris/engine/object/IrisBiome.java
@@ -484,11 +484,6 @@ public class IrisBiome extends IrisRegistrant implements IRare {
         });
     }
 
-    public IrisBiome infer(InferredType t, InferredType type) {
-        setInferredType(t.equals(InferredType.DEFER) ? type : t);
-        return this;
-    }
-
     public KList<BlockData> generateSeaLayers(double wx, double wz, RNG random, int maxDepth, IrisData rdata) {
         KList<BlockData> data = new KList<>();
 

--- a/src/main/java/com/volmit/iris/engine/object/IrisSpawner.java
+++ b/src/main/java/com/volmit/iris/engine/object/IrisSpawner.java
@@ -76,17 +76,17 @@ public class IrisSpawner extends IrisRegistrant {
     public boolean isValid(IrisBiome biome) {
         return switch (group) {
             case NORMAL -> switch (biome.getInferredType()) {
-                case SHORE, SEA, CAVE, DEFER -> false;
+                case SHORE, SEA, CAVE -> false;
                 case LAND -> true;
             };
             case CAVE -> true;
             case UNDERWATER -> switch (biome.getInferredType()) {
-                case SHORE, LAND, CAVE, DEFER -> false;
+                case SHORE, LAND, CAVE -> false;
                 case SEA -> true;
             };
             case BEACH -> switch (biome.getInferredType()) {
                 case SHORE -> true;
-                case LAND, CAVE, SEA, DEFER -> false;
+                case LAND, CAVE, SEA -> false;
             };
         };
     }


### PR DESCRIPTION
Terrain height was unreliable. Instead, we take an output more closely related to the continentStyle on the Dimension, as opposed to a way-down-the-line output, being the terrain height.