### PR TITLE
Add Settings ItemsAdder, Oraxen link

### DIFF
--- a/src/main/java/com/volmit/iris/core/IrisSettings.java
+++ b/src/main/java/com/volmit/iris/core/IrisSettings.java
@@ -41,6 +41,7 @@ public class IrisSettings {
     private IrisSettingsConcurrency concurrency = new IrisSettingsConcurrency();
     private IrisSettingsStudio studio = new IrisSettingsStudio();
     private IrisSettingsPerformance performance = new IrisSettingsPerformance();
+    private IrisSettingsLink link = new IrisSettingsLink();
 
     public static int getThreadCount(int c) {
         return switch (c) {
@@ -182,5 +183,11 @@ public class IrisSettings {
         public boolean openVSCode = true;
         public boolean disableTimeAndWeather = true;
         public boolean autoStartDefaultStudio = false;
+    }
+
+    @Data
+    public static class IrisSettingsLink {
+        public boolean itemAdder = true;
+        public boolean oraxen = true;
     }
 }

--- a/src/main/java/com/volmit/iris/core/link/ExternalDataProvider.java
+++ b/src/main/java/com/volmit/iris/core/link/ExternalDataProvider.java
@@ -35,4 +35,8 @@ public abstract class ExternalDataProvider {
     public abstract Identifier[] getItemTypes();
 
     public abstract boolean isValidProvider(Identifier id, boolean isItem);
+
+    public boolean isEnabledByDefault() {
+        return true;
+    }
 }

--- a/src/main/java/com/volmit/iris/core/link/ItemAdderDataProvider.java
+++ b/src/main/java/com/volmit/iris/core/link/ItemAdderDataProvider.java
@@ -1,5 +1,6 @@
 package com.volmit.iris.core.link;
 
+import com.volmit.iris.core.IrisSettings;
 import com.volmit.iris.util.collection.KList;
 import dev.lone.itemsadder.api.CustomBlock;
 import dev.lone.itemsadder.api.CustomStack;
@@ -64,5 +65,10 @@ public class ItemAdderDataProvider extends ExternalDataProvider {
     @Override
     public boolean isValidProvider(Identifier id, boolean isItem) {
         return isItem ? this.itemNamespaces.contains(id.namespace()) : this.blockNamespaces.contains(id.namespace());
+    }
+
+    @Override
+    public boolean isEnabledByDefault() {
+        return IrisSettings.get().getLink().isItemAdder();
     }
 }

--- a/src/main/java/com/volmit/iris/core/link/OraxenDataProvider.java
+++ b/src/main/java/com/volmit/iris/core/link/OraxenDataProvider.java
@@ -19,6 +19,7 @@
 package com.volmit.iris.core.link;
 
 import com.volmit.iris.Iris;
+import com.volmit.iris.core.IrisSettings;
 import com.volmit.iris.util.collection.KList;
 import com.volmit.iris.util.reflect.WrappedField;
 import io.th0rgal.oraxen.api.OraxenItems;
@@ -122,5 +123,10 @@ public class OraxenDataProvider extends ExternalDataProvider {
                 .filter(i -> i.getItems().contains(key.key()))
                 .findFirst()
                 .orElseThrow(() -> new MissingResourceException("Failed to find BlockData!", key.namespace(), key.key()));
+    }
+
+    @Override
+    public boolean isEnabledByDefault() {
+        return IrisSettings.get().getLink().isOraxen();
     }
 }

--- a/src/main/java/com/volmit/iris/core/service/ExternalDataSVC.java
+++ b/src/main/java/com/volmit/iris/core/service/ExternalDataSVC.java
@@ -49,7 +49,7 @@ public class ExternalDataSVC implements IrisService {
 
     public void addProvider(ExternalDataProvider... provider) {
         for (ExternalDataProvider p : provider) {
-            if (p.getPlugin() != null) {
+            if (p.getPlugin() != null && p.isEnabledByDefault()) {
                 providers.add(p);
                 p.init();
             }


### PR DESCRIPTION
Some people use both Iris and ItemsAdder, but there are also cases that Iris does not use ItemsAdder items.
I am one of them and we should be able to run the server normally.
So I tweaked the code to be able to set links with other plugins.
