### PR TITLE
Fix Oraxen implementation

### DIFF
--- a/src/main/java/com/volmit/iris/core/link/Identifier.java
+++ b/src/main/java/com/volmit/iris/core/link/Identifier.java
@@ -7,7 +7,7 @@ public record Identifier(String namespace, String key) {
     private static final String DEFAULT_NAMESPACE = "minecraft";
 
     public static Identifier fromString(String id) {
-        String[] strings = id.split(":", 1);
+        String[] strings = id.split(":", 2);
         if(strings.length == 1) {
             return new Identifier(DEFAULT_NAMESPACE, strings[0]);
         } else {


### PR DESCRIPTION
i noticed that with the current split limit the id would be considered minecraft:oraxen:<block-id> instead of oraxen:<block-id>