### PR TITLE
Fix unresolved dependency error

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -133,6 +133,7 @@ dependencies {
     implementation 'org.bukkit:craftbukkit:1.20.1-R0.1-SNAPSHOT:remapped-mojang' //[NMS]
 
     // Third Party Integrations
+    implementation 'com.ticxo.playeranimator:PlayerAnimator:R1.2.7'
     implementation 'com.github.oraxen:oraxen:1.152.5'
     implementation 'com.github.LoneDev6:api-itemsadder:3.4.1-r4'
     implementation 'me.clip:placeholderapi:2.11.3'


### PR DESCRIPTION
When I attempt to build the project using the steps outlined in the [README.md](https://github.com/VolmitSoftware/Iris#readme) file for macOS, `./gradlew setup` works perfectly, but the following error shows up once you get to the `./gradlew iris` part:
<details>
<summary>Command Error</summary>

```zsh
christolis@tentacles:/tmp/Iris$ ./gradlew iris
FAILURE: Build failed with an exception.

* What went wrong:
Could not determine the dependencies of task ':shadowJar'.
> Could not resolve all dependencies for configuration ':runtimeClasspath'.
   > Could not resolve com.ticxo.playeranimator:PlayerAnimator:R1.2.5.
     Required by:
         project : > com.github.oraxen:oraxen:1.152.5
      > Could not resolve com.ticxo.playeranimator:PlayerAnimator:R1.2.5.
         > inconsistent module metadata found. Descriptor: com.ticxo.playeranimator:PlayerAnimator:R1.2.7 Errors: bad version: expected='R1.2.5' found='R1.2.7'

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 5s
```

</details>

It appears that by adding the `com.ticxo.playeranimator:PlayerAnimator:R1.2.7` dependency to `build.gradle`, the problem becomes fixed and the project builds successfully, although I have a feeling that this is a hacky workaround and there might be something else causing this issue.

**EDIT:** This appears to be an issue for operating systems other than macOS, so I updated the title of this PR.