### PR TITLE
re-add setup task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -295,7 +295,7 @@ if (JavaVersion.current().toString() != "17") {
 
 task iris(type: Copy) {
     group "iris"
-    from new File(buildDir, "Iris-${version}.jar")
+    from new File(buildDir, "libs/Iris-${version}.jar")
     into buildDir
     dependsOn(build)
 }

--- a/build.gradle
+++ b/build.gradle
@@ -300,6 +300,13 @@ task iris(type: Copy) {
     dependsOn(build)
 }
 
+task setup() {
+    group "iris"
+    NMS_BINDINGS.each {
+        dependsOn(project(":nms:${it.key}").executeBuildTools)
+    }
+}
+
 def registerCustomOutputTask(name, path) {
     if (!System.properties['os.name'].toLowerCase().contains('windows')) {
         return;


### PR DESCRIPTION
This task itself isn't needed, but if something goes wrong one can manually trigger the build tools of all nms modules