### PR TITLE
Fixed file separators in '/iris import'

### DIFF
--- a/core/src/main/java/com/volmit/iris/core/commands/CommandIris.java
+++ b/core/src/main/java/com/volmit/iris/core/commands/CommandIris.java
@@ -447,7 +447,7 @@ public class CommandIris implements DecreeExecutor {
         }
         WorldToLoad = world;
         File BUKKIT_YML = new File("bukkit.yml");
-        String pathtodim = world + "\\iris\\pack\\dimensions\\";
+        String pathtodim = world + File.separator +"iris"+File.separator +"pack"+File.separator +"dimensions"+File.separator;
         File directory = new File(Bukkit.getWorldContainer(), pathtodim);
 
         String dimension = null;


### PR DESCRIPTION
Fixed backslashes being used as the file separator regardless of platform (in /iris import)).