### PR TITLE
Fix Pregen oversight

### DIFF
--- a/core/src/main/java/com/volmit/iris/core/pregenerator/IrisPregenerator.java
+++ b/core/src/main/java/com/volmit/iris/core/pregenerator/IrisPregenerator.java
@@ -167,7 +167,10 @@ public class IrisPregenerator {
         generator.close();
         ticker.interrupt();
         listener.onClose();
-        getMantle().trim(0, 0);
+        Mantle mantle = getMantle();
+        if (mantle != null) {
+            mantle.trim(0, 0);
+        }
     }
 
     private void visitRegion(int x, int z, boolean regions) {


### PR DESCRIPTION
Fixes the following error when pregenerating a non iris world
![image](https://github.com/VolmitSoftware/Iris/assets/47589149/c3fb5876-c7c7-4f74-a272-4feb59da67f6)
