### PR TITLE
Remove Cherry Grove from 1.19.4 biomes list

### DIFF
--- a/nms/v1_19_R3/src/main/java/com/volmit/iris/core/nms/v1_19_R3/NMSBinding.java
+++ b/nms/v1_19_R3/src/main/java/com/volmit/iris/core/nms/v1_19_R3/NMSBinding.java
@@ -278,7 +278,7 @@ public class NMSBinding implements INMSBinding {
 
     @Override
     public KList<Biome> getBiomes() {
-        return new KList<>(Biome.values()).qadd(Biome.CHERRY_GROVE).qdel(Biome.CUSTOM);
+        return new KList<>(Biome.values()).qdel(Biome.CHERRY_GROVE).qdel(Biome.CUSTOM);
     }
 
     @Override


### PR DESCRIPTION
This PR fixes the crash when creating an iris world in 1.19.4 without experimental 1.20 enabled
https://discord.com/channels/189665083817852928/1211748994988904448/1211808112479043675
https://discord.com/channels/189665083817852928/1206936773477928990