### PR TITLE
horse instead of camel

### DIFF
--- a/nms/v1_19_R3/src/main/java/com/volmit/iris/core/nms/v1_19_R3/NMSBinding.java
+++ b/nms/v1_19_R3/src/main/java/com/volmit/iris/core/nms/v1_19_R3/NMSBinding.java
@@ -491,6 +491,9 @@ public class NMSBinding implements INMSBinding {
 
     @Override
     public Entity spawnEntity(Location location, EntityType type, CreatureSpawnEvent.SpawnReason reason) {
+        if (type == EntityType.CAMEL) {
+            type = EntityType.HORSE;
+        }
         return ((CraftWorld) location.getWorld()).spawn(location, type.getEntityClass(), null, reason);
     }
 


### PR DESCRIPTION
Replaces camels with horses on a specific version due to a spigot bug. Alternatively, pull the other PR to cancel these spawns outright, instead of falling back to horses,