### PR TITLE
improve custom block/item api to allow custom settings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,7 @@ registerCustomOutputTask('Pixel', 'C://Users/repix/Iris Dimension Engine/1.20.4 
 // ========================== UNIX ==============================
 registerCustomOutputTaskUnix('CyberpwnLT', '/Users/danielmills/development/server/plugins')
 registerCustomOutputTaskUnix('PsychoLT', '/Volumes/PRO-G40/Minecraft/MinecraftDevelopment/Server/plugins')
+registerCustomOutputTaskUnix('CrazyDev22LT', '/home/julian/Desktop/server/plugins')
 // ==============================================================
 
 def NMS_BINDINGS = Map.of(
@@ -251,6 +252,7 @@ allprojects {
         maven { url "https://repo.triumphteam.dev/snapshots" }
         maven { url "https://repo.mineinabyss.com/releases" }
         maven { url 'https://hub.jeff-media.com/nexus/repository/jeff-media-public/' }
+        maven { url "https://repo.oraxen.com/releases" }
     }
 
     dependencies {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -62,7 +62,7 @@ dependencies {
 
     // Third Party Integrations
     compileOnly 'com.ticxo.playeranimator:PlayerAnimator:R1.2.7'
-    compileOnly 'com.github.oraxen:oraxen:1.158.0'
+    compileOnly 'io.th0rgal:oraxen:1.173.0'
     compileOnly 'com.github.LoneDev6:api-itemsadder:3.4.1-r4'
     compileOnly 'com.github.PlaceholderAPI:placeholderapi:2.11.3'
     compileOnly 'com.github.Ssomar-Developement:SCore:4.23.10.8'

--- a/core/src/main/java/com/volmit/iris/core/link/EcoItemsDataProvider.java
+++ b/core/src/main/java/com/volmit/iris/core/link/EcoItemsDataProvider.java
@@ -2,6 +2,7 @@ package com.volmit.iris.core.link;
 
 import com.volmit.iris.Iris;
 import com.volmit.iris.util.collection.KList;
+import com.volmit.iris.util.collection.KMap;
 import com.volmit.iris.util.reflect.WrappedField;
 import com.willfp.ecoitems.items.EcoItem;
 import com.willfp.ecoitems.items.EcoItems;
@@ -33,12 +34,12 @@ public class EcoItemsDataProvider extends ExternalDataProvider {
     }
 
     @Override
-    public BlockData getBlockData(Identifier blockId) throws MissingResourceException {
+    public BlockData getBlockData(Identifier blockId, KMap<String, String> state) throws MissingResourceException {
         throw new MissingResourceException("Failed to find BlockData!", blockId.namespace(), blockId.key());
     }
 
     @Override
-    public ItemStack getItemStack(Identifier itemId) throws MissingResourceException {
+    public ItemStack getItemStack(Identifier itemId, KMap<String, Object> customNbt) throws MissingResourceException {
         EcoItem item = EcoItems.INSTANCE.getByID(itemId.key());
         if (item == null) throw new MissingResourceException("Failed to find Item!", itemId.namespace(), itemId.key());
         return itemStack.get(item).clone();

--- a/core/src/main/java/com/volmit/iris/core/link/ExecutableItemsDataProvider.java
+++ b/core/src/main/java/com/volmit/iris/core/link/ExecutableItemsDataProvider.java
@@ -3,6 +3,7 @@ package com.volmit.iris.core.link;
 import com.ssomar.score.api.executableitems.ExecutableItemsAPI;
 import com.volmit.iris.Iris;
 import com.volmit.iris.util.collection.KList;
+import com.volmit.iris.util.collection.KMap;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.inventory.ItemStack;
 
@@ -20,12 +21,12 @@ public class ExecutableItemsDataProvider extends ExternalDataProvider {
     }
 
     @Override
-    public BlockData getBlockData(Identifier blockId) throws MissingResourceException {
+    public BlockData getBlockData(Identifier blockId, KMap<String, String> state) throws MissingResourceException {
         throw new MissingResourceException("Failed to find BlockData!", blockId.namespace(), blockId.key());
     }
 
     @Override
-    public ItemStack getItemStack(Identifier itemId) throws MissingResourceException {
+    public ItemStack getItemStack(Identifier itemId, KMap<String, Object> customNbt) throws MissingResourceException {
         return ExecutableItemsAPI.getExecutableItemsManager().getExecutableItem(itemId.key())
                 .map(item -> item.buildItem(1, Optional.empty()))
                 .orElseThrow(() -> new MissingResourceException("Failed to find ItemData!", itemId.namespace(), itemId.key()));

--- a/core/src/main/java/com/volmit/iris/core/link/ExternalDataProvider.java
+++ b/core/src/main/java/com/volmit/iris/core/link/ExternalDataProvider.java
@@ -1,6 +1,7 @@
 package com.volmit.iris.core.link;
 
 import com.volmit.iris.engine.framework.Engine;
+import com.volmit.iris.util.collection.KMap;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.bukkit.Bukkit;
@@ -27,10 +28,19 @@ public abstract class ExternalDataProvider {
 
     public abstract void init();
 
-    public abstract BlockData getBlockData(Identifier blockId) throws MissingResourceException;
+    public BlockData getBlockData(Identifier blockId) throws MissingResourceException {
+        return getBlockData(blockId, new KMap<>());
+    }
 
-    public abstract ItemStack getItemStack(Identifier itemId) throws MissingResourceException;
-    public void processUpdate(Engine engine, Block block, Identifier blockId) {};
+    public abstract BlockData getBlockData(Identifier blockId, KMap<String, String> state) throws MissingResourceException;
+
+    public ItemStack getItemStack(Identifier itemId) throws MissingResourceException {
+        return getItemStack(itemId, new KMap<>());
+    }
+
+    public abstract ItemStack getItemStack(Identifier itemId, KMap<String, Object> customNbt) throws MissingResourceException;
+
+    public void processUpdate(Engine engine, Block block, Identifier blockId) {}
 
     public abstract Identifier[] getBlockTypes();
 

--- a/core/src/main/java/com/volmit/iris/core/link/ItemAdderDataProvider.java
+++ b/core/src/main/java/com/volmit/iris/core/link/ItemAdderDataProvider.java
@@ -2,6 +2,7 @@ package com.volmit.iris.core.link;
 
 import com.volmit.iris.Iris;
 import com.volmit.iris.util.collection.KList;
+import com.volmit.iris.util.collection.KMap;
 import dev.lone.itemsadder.api.CustomBlock;
 import dev.lone.itemsadder.api.CustomStack;
 import org.bukkit.block.data.BlockData;
@@ -32,12 +33,12 @@ public class ItemAdderDataProvider extends ExternalDataProvider {
     }
 
     @Override
-    public BlockData getBlockData(Identifier blockId) throws MissingResourceException {
+    public BlockData getBlockData(Identifier blockId, KMap<String, String> state) throws MissingResourceException {
         return CustomBlock.getBaseBlockData(blockId.toString());
     }
 
     @Override
-    public ItemStack getItemStack(Identifier itemId) throws MissingResourceException {
+    public ItemStack getItemStack(Identifier itemId, KMap<String, Object> customNbt) throws MissingResourceException {
         CustomStack stack = CustomStack.getInstance(itemId.toString());
         if (stack == null) {
             throw new MissingResourceException("Failed to find ItemData!", itemId.namespace(), itemId.key());

--- a/core/src/main/java/com/volmit/iris/core/link/OraxenDataProvider.java
+++ b/core/src/main/java/com/volmit/iris/core/link/OraxenDataProvider.java
@@ -147,6 +147,7 @@ public class OraxenDataProvider extends ExternalDataProvider {
 
             if (type != null) {
                 var biomeColor = INMS.get().getBiomeColor(block.getLocation(), type);
+                if (biomeColor == null) return;
                 var potionColor = Color.fromARGB(biomeColor.getAlpha(), biomeColor.getRed(), biomeColor.getGreen(), biomeColor.getBlue());
                 if (itemStack.getItemMeta() instanceof PotionMeta meta) {
                     meta.setColor(potionColor);

--- a/core/src/main/java/com/volmit/iris/core/link/OraxenDataProvider.java
+++ b/core/src/main/java/com/volmit/iris/core/link/OraxenDataProvider.java
@@ -19,10 +19,16 @@
 package com.volmit.iris.core.link;
 
 import com.volmit.iris.Iris;
+import com.volmit.iris.core.nms.INMS;
+import com.volmit.iris.core.nms.container.BiomeColor;
+import com.volmit.iris.core.service.ExternalDataSVC;
+import com.volmit.iris.engine.data.cache.Cache;
 import com.volmit.iris.engine.framework.Engine;
 import com.volmit.iris.util.collection.KList;
+import com.volmit.iris.util.collection.KMap;
 import com.volmit.iris.util.data.B;
 import com.volmit.iris.util.data.IrisBlockData;
+import com.volmit.iris.util.math.RNG;
 import com.volmit.iris.util.reflect.WrappedField;
 import io.th0rgal.oraxen.api.OraxenItems;
 import io.th0rgal.oraxen.items.ItemBuilder;
@@ -36,15 +42,22 @@ import io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.FurnitureMechanic
 import io.th0rgal.oraxen.mechanics.provided.gameplay.noteblock.NoteBlockMechanicFactory;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.stringblock.StringBlockMechanicFactory;
 import org.bukkit.Bukkit;
+import org.bukkit.Color;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.block.data.MultipleFacing;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.ItemDisplay;
+import org.bukkit.entity.ItemFrame;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.PotionMeta;
 
 import java.util.Map;
 import java.util.MissingResourceException;
 import java.util.Optional;
+import java.util.function.Consumer;
 
 public class OraxenDataProvider extends ExternalDataProvider {
 
@@ -66,7 +79,7 @@ public class OraxenDataProvider extends ExternalDataProvider {
     }
 
     @Override
-    public BlockData getBlockData(Identifier blockId) throws MissingResourceException {
+    public BlockData getBlockData(Identifier blockId, KMap<String, String> state) throws MissingResourceException {
         MechanicFactory factory = getFactory(blockId);
         if (factory instanceof NoteBlockMechanicFactory f)
             return f.createNoteBlockData(blockId.key());
@@ -77,22 +90,70 @@ public class OraxenDataProvider extends ExternalDataProvider {
         } else if (factory instanceof StringBlockMechanicFactory f) {
             return f.createTripwireData(blockId.key());
         } else if (factory instanceof FurnitureFactory) {
-            return new IrisBlockData(B.getAir(), blockId);
+            return new IrisBlockData(B.getAir(), ExternalDataSVC.buildState(blockId, state));
         } else
             throw new MissingResourceException("Failed to find BlockData!", blockId.namespace(), blockId.key());
     }
 
     @Override
-    public ItemStack getItemStack(Identifier itemId) throws MissingResourceException {
+    public ItemStack getItemStack(Identifier itemId, KMap<String, Object> customNbt) throws MissingResourceException {
         Optional<ItemBuilder> opt = OraxenItems.getOptionalItemById(itemId.key());
         return opt.orElseThrow(() -> new MissingResourceException("Failed to find ItemData!", itemId.namespace(), itemId.key())).build();
     }
 
     @Override
     public void processUpdate(Engine engine, Block block, Identifier blockId) {
+        var pair = ExternalDataSVC.parseState(blockId);
+        var state = pair.getB();
+        blockId = pair.getA();
         Mechanic mechanic = getFactory(blockId).getMechanic(blockId.key());
         if (mechanic instanceof FurnitureMechanic f) {
-            f.place(block.getLocation());
+            float yaw = 0;
+            BlockFace face = BlockFace.NORTH;
+
+            long seed = engine.getSeedManager().getSeed() + Cache.key(block.getX(), block.getZ()) + block.getY();
+            RNG rng = new RNG(seed);
+            if ("true".equals(state.get("randomYaw"))) {
+                yaw = rng.f(0, 360);
+            } else if (state.containsKey("yaw")) {
+                yaw = Float.parseFloat(state.get("yaw"));
+            }
+            if ("true".equals(state.get("randomFace"))) {
+                BlockFace[] faces = BlockFace.values();
+                face = faces[rng.i(0, faces.length - 1)];
+            } else if (state.containsKey("face")) {
+                face = BlockFace.valueOf(state.get("face").toUpperCase());
+            }
+            if (face == BlockFace.SELF) {
+                face = BlockFace.NORTH;
+            }
+            ItemStack itemStack = OraxenItems.getItemById(f.getItemID()).build();
+            Entity entity = f.place(block.getLocation(), itemStack, yaw, face, false);
+
+            Consumer<ItemStack> setter = null;
+            if (entity instanceof ItemFrame frame) {
+                itemStack = frame.getItem();
+                setter = frame::setItem;
+            } else if (entity instanceof ItemDisplay display) {
+                itemStack = display.getItemStack();
+                setter = display::setItemStack;
+            }
+            if (setter == null || itemStack == null) return;
+
+            BiomeColor type = null;
+            try {
+                type = BiomeColor.valueOf(state.get("matchBiome").toUpperCase());
+            } catch (NullPointerException | IllegalArgumentException ignored) {}
+
+            if (type != null) {
+                var biomeColor = INMS.get().getBiomeColor(block.getLocation(), type);
+                var potionColor = Color.fromARGB(biomeColor.getAlpha(), biomeColor.getRed(), biomeColor.getGreen(), biomeColor.getBlue());
+                if (itemStack.getItemMeta() instanceof PotionMeta meta) {
+                    meta.setColor(potionColor);
+                    itemStack.setItemMeta(meta);
+                }
+            }
+            setter.accept(itemStack);
         }
     }
 

--- a/core/src/main/java/com/volmit/iris/core/loader/ResourceLoader.java
+++ b/core/src/main/java/com/volmit/iris/core/loader/ResourceLoader.java
@@ -362,7 +362,12 @@ public class ResourceLoader<T extends IrisRegistrant> implements MeteredCache {
             if (folderCache.get() == null) {
                 KList<File> fc = new KList<>();
 
-                for (File i : root.listFiles()) {
+                File[] files = root.listFiles();
+                if (files == null) {
+                    throw new IllegalStateException("Failed to list files in " + root);
+                }
+
+                for (File i : files) {
                     if (i.isDirectory()) {
                         if (i.getName().equals(folderName)) {
                             fc.add(i);

--- a/core/src/main/java/com/volmit/iris/core/nms/INMSBinding.java
+++ b/core/src/main/java/com/volmit/iris/core/nms/INMSBinding.java
@@ -18,6 +18,7 @@
 
 package com.volmit.iris.core.nms;
 
+import com.volmit.iris.core.nms.container.BiomeColor;
 import com.volmit.iris.core.nms.datapack.DataVersion;
 import com.volmit.iris.engine.framework.Engine;
 import com.volmit.iris.util.collection.KList;
@@ -38,6 +39,8 @@ import org.bukkit.entity.EntityType;
 import org.bukkit.event.entity.CreatureSpawnEvent;
 import org.bukkit.generator.ChunkGenerator;
 import org.bukkit.inventory.ItemStack;
+
+import java.awt.*;
 
 public interface INMSBinding {
     boolean hasTile(Location l);
@@ -111,6 +114,8 @@ public interface INMSBinding {
     Vector3d getBoundingbox(org.bukkit.entity.EntityType entity);
     
     Entity spawnEntity(Location location, EntityType type, CreatureSpawnEvent.SpawnReason reason);
+
+    Color getBiomeColor(Location location, BiomeColor type);
 
     default DataVersion getDataVersion() {
         return DataVersion.V1192;

--- a/core/src/main/java/com/volmit/iris/core/nms/container/BiomeColor.java
+++ b/core/src/main/java/com/volmit/iris/core/nms/container/BiomeColor.java
@@ -1,0 +1,10 @@
+package com.volmit.iris.core.nms.container;
+
+public enum BiomeColor {
+    FOG,
+    WATER,
+    WATER_FOG,
+    SKY,
+    FOLIAGE,
+    GRASS
+}

--- a/core/src/main/java/com/volmit/iris/core/nms/v1X/NMSBinding1X.java
+++ b/core/src/main/java/com/volmit/iris/core/nms/v1X/NMSBinding1X.java
@@ -20,6 +20,7 @@ package com.volmit.iris.core.nms.v1X;
 
 import com.volmit.iris.Iris;
 import com.volmit.iris.core.nms.INMSBinding;
+import com.volmit.iris.core.nms.container.BiomeColor;
 import com.volmit.iris.core.nms.container.BlockPos;
 import com.volmit.iris.engine.framework.Engine;
 import com.volmit.iris.util.collection.KList;
@@ -39,6 +40,8 @@ import org.bukkit.entity.EntityType;
 import org.bukkit.event.entity.CreatureSpawnEvent;
 import org.bukkit.generator.ChunkGenerator;
 import org.bukkit.inventory.ItemStack;
+
+import java.awt.*;
 
 public class NMSBinding1X implements INMSBinding {
     private static final boolean supportsCustomHeight = testCustomHeight();
@@ -95,6 +98,11 @@ public class NMSBinding1X implements INMSBinding {
     @Override
     public Entity spawnEntity(Location location, EntityType type, CreatureSpawnEvent.SpawnReason reason) {
         return location.getWorld().spawnEntity(location, type);
+    }
+
+    @Override
+    public Color getBiomeColor(Location location, BiomeColor type) {
+        return Color.GREEN;
     }
 
     @Override

--- a/core/src/main/java/com/volmit/iris/engine/jigsaw/PlannedStructure.java
+++ b/core/src/main/java/com/volmit/iris/engine/jigsaw/PlannedStructure.java
@@ -25,6 +25,7 @@ import com.volmit.iris.engine.framework.Engine;
 import com.volmit.iris.engine.framework.placer.WorldObjectPlacer;
 import com.volmit.iris.engine.object.*;
 import com.volmit.iris.util.collection.KList;
+import com.volmit.iris.util.data.IrisBlockData;
 import com.volmit.iris.util.mantle.Mantle;
 import com.volmit.iris.util.math.Position2;
 import com.volmit.iris.util.math.RNG;
@@ -149,6 +150,9 @@ public class PlannedStructure {
         return v.place(xx, height, zz, placer, options, rng, (b, data) -> {
             e.set(b.getX(), b.getY(), b.getZ(), v.getLoadKey() + "@" + id);
             e.set(b.getX(), b.getY(), b.getZ(), container);
+            if (data instanceof IrisBlockData d) {
+                e.set(b.getX(), b.getY(), b.getZ(), d.getCustom());
+            }
         }, null, getData().getEngine() != null ? getData() : eng.getData()) != -1;
     }
 

--- a/core/src/main/java/com/volmit/iris/engine/mantle/components/MantleObjectComponent.java
+++ b/core/src/main/java/com/volmit/iris/engine/mantle/components/MantleObjectComponent.java
@@ -27,6 +27,7 @@ import com.volmit.iris.engine.object.*;
 import com.volmit.iris.util.collection.KSet;
 import com.volmit.iris.util.context.ChunkContext;
 import com.volmit.iris.util.data.B;
+import com.volmit.iris.util.data.IrisBlockData;
 import com.volmit.iris.util.documentation.BlockCoordinates;
 import com.volmit.iris.util.documentation.ChunkCoordinates;
 import com.volmit.iris.util.mantle.MantleFlag;
@@ -102,6 +103,9 @@ public class MantleObjectComponent extends IrisMantleComponent {
                 writer.setData(b.getX(), b.getY(), b.getZ(), v.getLoadKey() + "@" + id);
                 if (objectPlacement.isDolphinTarget() && objectPlacement.isUnderwater() && B.isStorageChest(data)) {
                     writer.setData(b.getX(), b.getY(), b.getZ(), MatterStructurePOI.BURIED_TREASURE);
+                }
+                if (data instanceof IrisBlockData d) {
+                    writer.setData(b.getX(), b.getY(), b.getZ(), d.getCustom());
                 }
             }, null, getData());
         }

--- a/core/src/main/java/com/volmit/iris/engine/object/IrisLoot.java
+++ b/core/src/main/java/com/volmit/iris/engine/object/IrisLoot.java
@@ -29,7 +29,6 @@ import com.volmit.iris.util.collection.KMap;
 import com.volmit.iris.util.data.B;
 import com.volmit.iris.util.format.C;
 import com.volmit.iris.util.format.Form;
-import com.volmit.iris.util.json.JSONObject;
 import com.volmit.iris.util.math.RNG;
 import com.volmit.iris.util.noise.CNG;
 import lombok.AllArgsConstructor;
@@ -146,7 +145,7 @@ public class IrisLoot {
     // TODO Better Third Party Item Acquisition
     private ItemStack getItemStack(RNG rng) {
         if (!type.startsWith("minecraft:") && type.contains(":")) {
-            Optional<ItemStack> opt = Iris.service(ExternalDataSVC.class).getItemStack(Identifier.fromString(type));
+            Optional<ItemStack> opt = Iris.service(ExternalDataSVC.class).getItemStack(Identifier.fromString(type), customNbt);
             if (opt.isEmpty()) {
                 Iris.warn("Unknown Material: " + type);
                 return new ItemStack(Material.AIR);

--- a/nms/v1_19_R1/src/main/java/com/volmit/iris/core/nms/v1_19_R1/NMSBinding.java
+++ b/nms/v1_19_R1/src/main/java/com/volmit/iris/core/nms/v1_19_R1/NMSBinding.java
@@ -1,5 +1,6 @@
 package com.volmit.iris.core.nms.v1_19_R1;
 
+import java.awt.Color;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
@@ -12,6 +13,8 @@ import java.util.List;
 import java.util.Vector;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import com.volmit.iris.core.nms.container.BiomeColor;
+import net.minecraft.world.level.LevelReader;
 import org.bukkit.*;
 import org.bukkit.block.Biome;
 import org.bukkit.block.data.BlockData;
@@ -515,6 +518,24 @@ public class NMSBinding implements INMSBinding {
     @Override
     public Entity spawnEntity(Location location, org.bukkit.entity.EntityType type, CreatureSpawnEvent.SpawnReason reason) {
         return ((CraftWorld) location.getWorld()).spawn(location, type.getEntityClass(), null, reason);
+    }
+
+    @Override
+    public Color getBiomeColor(Location location, BiomeColor type) {
+        LevelReader reader = ((CraftWorld) location.getWorld()).getHandle();
+        var holder = reader.getBiome(new BlockPos(location.getBlockX(), location.getBlockY(), location.getBlockZ()));
+        var biome = holder.value();
+        if (biome == null) throw new IllegalArgumentException("Invalid biome: " + holder.unwrapKey().orElse(null));
+
+        int rgba = switch (type) {
+            case FOG -> biome.getFogColor();
+            case WATER -> biome.getWaterColor();
+            case WATER_FOG -> biome.getWaterFogColor();
+            case SKY -> biome.getSkyColor();
+            case FOLIAGE -> biome.getFoliageColor();
+            case GRASS -> biome.getGrassColor(location.getBlockX(), location.getBlockZ());
+        };
+        return new Color(rgba, true);
     }
 
     private static Field getField(Class<?> clazz, Class<?> fieldType) throws NoSuchFieldException {

--- a/nms/v1_19_R2/src/main/java/com/volmit/iris/core/nms/v1_19_R2/NMSBinding.java
+++ b/nms/v1_19_R2/src/main/java/com/volmit/iris/core/nms/v1_19_R2/NMSBinding.java
@@ -1,5 +1,6 @@
 package com.volmit.iris.core.nms.v1_19_R2;
 
+import java.awt.Color;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
@@ -12,6 +13,8 @@ import java.util.List;
 import java.util.Vector;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import com.volmit.iris.core.nms.container.BiomeColor;
+import net.minecraft.world.level.LevelReader;
 import org.bukkit.*;
 import org.bukkit.block.Biome;
 import org.bukkit.block.data.BlockData;
@@ -517,6 +520,24 @@ public class NMSBinding implements INMSBinding {
     @Override
     public Entity spawnEntity(Location location,  org.bukkit.entity.EntityType type, CreatureSpawnEvent.SpawnReason reason) {
         return ((CraftWorld) location.getWorld()).spawn(location, type.getEntityClass(), null, reason);
+    }
+
+    @Override
+    public Color getBiomeColor(Location location, BiomeColor type) {
+        LevelReader reader = ((CraftWorld) location.getWorld()).getHandle();
+        var holder = reader.getBiome(new BlockPos(location.getBlockX(), location.getBlockY(), location.getBlockZ()));
+        var biome = holder.value();
+        if (biome == null) throw new IllegalArgumentException("Invalid biome: " + holder.unwrapKey().orElse(null));
+
+        int rgba = switch (type) {
+            case FOG -> biome.getFogColor();
+            case WATER -> biome.getWaterColor();
+            case WATER_FOG -> biome.getWaterFogColor();
+            case SKY -> biome.getSkyColor();
+            case FOLIAGE -> biome.getFoliageColor();
+            case GRASS -> biome.getGrassColor(location.getBlockX(), location.getBlockZ());
+        };
+        return new Color(rgba, true);
     }
 
     private static Field getField(Class<?> clazz, Class<?> fieldType) throws NoSuchFieldException {

--- a/nms/v1_19_R2/src/main/java/com/volmit/iris/core/nms/v1_19_R2/NMSBinding.java
+++ b/nms/v1_19_R2/src/main/java/com/volmit/iris/core/nms/v1_19_R2/NMSBinding.java
@@ -537,6 +537,12 @@ public class NMSBinding implements INMSBinding {
             case FOLIAGE -> biome.getFoliageColor();
             case GRASS -> biome.getGrassColor(location.getBlockX(), location.getBlockZ());
         };
+        if (rgba == 0) {
+            if (BiomeColor.FOLIAGE == type && biome.getSpecialEffects().getFoliageColorOverride().isEmpty())
+                return null;
+            if (BiomeColor.GRASS == type && biome.getSpecialEffects().getGrassColorOverride().isEmpty())
+                return null;
+        }
         return new Color(rgba, true);
     }
 

--- a/nms/v1_19_R3/src/main/java/com/volmit/iris/core/nms/v1_19_R3/NMSBinding.java
+++ b/nms/v1_19_R3/src/main/java/com/volmit/iris/core/nms/v1_19_R3/NMSBinding.java
@@ -1,5 +1,6 @@
 package com.volmit.iris.core.nms.v1_19_R3;
 
+import java.awt.Color;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
@@ -12,6 +13,8 @@ import java.util.List;
 import java.util.Vector;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import com.volmit.iris.core.nms.container.BiomeColor;
+import net.minecraft.world.level.LevelReader;
 import org.bukkit.*;
 import org.bukkit.block.Biome;
 import org.bukkit.block.data.BlockData;
@@ -521,6 +524,24 @@ public class NMSBinding implements INMSBinding {
             return null;
         }
         return ((CraftWorld) location.getWorld()).spawn(location, type.getEntityClass(), null, reason);
+    }
+
+    @Override
+    public Color getBiomeColor(Location location, BiomeColor type) {
+        LevelReader reader = ((CraftWorld) location.getWorld()).getHandle();
+        var holder = reader.getBiome(new BlockPos(location.getBlockX(), location.getBlockY(), location.getBlockZ()));
+        var biome = holder.value();
+        if (biome == null) throw new IllegalArgumentException("Invalid biome: " + holder.unwrapKey().orElse(null));
+
+        int rgba = switch (type) {
+            case FOG -> biome.getFogColor();
+            case WATER -> biome.getWaterColor();
+            case WATER_FOG -> biome.getWaterFogColor();
+            case SKY -> biome.getSkyColor();
+            case FOLIAGE -> biome.getFoliageColor();
+            case GRASS -> biome.getGrassColor(location.getBlockX(), location.getBlockZ());
+        };
+        return new Color(rgba, true);
     }
 
     private static Field getField(Class<?> clazz, Class<?> fieldType) throws NoSuchFieldException {

--- a/nms/v1_19_R3/src/main/java/com/volmit/iris/core/nms/v1_19_R3/NMSBinding.java
+++ b/nms/v1_19_R3/src/main/java/com/volmit/iris/core/nms/v1_19_R3/NMSBinding.java
@@ -541,6 +541,12 @@ public class NMSBinding implements INMSBinding {
             case FOLIAGE -> biome.getFoliageColor();
             case GRASS -> biome.getGrassColor(location.getBlockX(), location.getBlockZ());
         };
+        if (rgba == 0) {
+            if (BiomeColor.FOLIAGE == type && biome.getSpecialEffects().getFoliageColorOverride().isEmpty())
+                return null;
+            if (BiomeColor.GRASS == type && biome.getSpecialEffects().getGrassColorOverride().isEmpty())
+                return null;
+        }
         return new Color(rgba, true);
     }
 

--- a/nms/v1_20_R1/src/main/java/com/volmit/iris/core/nms/v1_20_R1/NMSBinding.java
+++ b/nms/v1_20_R1/src/main/java/com/volmit/iris/core/nms/v1_20_R1/NMSBinding.java
@@ -540,6 +540,12 @@ public class NMSBinding implements INMSBinding {
             case FOLIAGE -> biome.getFoliageColor();
             case GRASS -> biome.getGrassColor(location.getBlockX(), location.getBlockZ());
         };
+        if (rgba == 0) {
+            if (BiomeColor.FOLIAGE == type && biome.getSpecialEffects().getFoliageColorOverride().isEmpty())
+                return null;
+            if (BiomeColor.GRASS == type && biome.getSpecialEffects().getGrassColorOverride().isEmpty())
+                return null;
+        }
         return new Color(rgba, true);
     }
 

--- a/nms/v1_20_R2/src/main/java/com/volmit/iris/core/nms/v1_20_R2/NMSBinding.java
+++ b/nms/v1_20_R2/src/main/java/com/volmit/iris/core/nms/v1_20_R2/NMSBinding.java
@@ -538,6 +538,12 @@ public class NMSBinding implements INMSBinding {
             case FOLIAGE -> biome.getFoliageColor();
             case GRASS -> biome.getGrassColor(location.getBlockX(), location.getBlockZ());
         };
+        if (rgba == 0) {
+            if (BiomeColor.FOLIAGE == type && biome.getSpecialEffects().getFoliageColorOverride().isEmpty())
+                return null;
+            if (BiomeColor.GRASS == type && biome.getSpecialEffects().getGrassColorOverride().isEmpty())
+                return null;
+        }
         return new Color(rgba, true);
     }
 

--- a/nms/v1_20_R2/src/main/java/com/volmit/iris/core/nms/v1_20_R2/NMSBinding.java
+++ b/nms/v1_20_R2/src/main/java/com/volmit/iris/core/nms/v1_20_R2/NMSBinding.java
@@ -1,5 +1,6 @@
 package com.volmit.iris.core.nms.v1_20_R2;
 
+import java.awt.Color;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
@@ -12,6 +13,8 @@ import java.util.List;
 import java.util.Vector;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import com.volmit.iris.core.nms.container.BiomeColor;
+import net.minecraft.world.level.LevelReader;
 import org.bukkit.*;
 import org.bukkit.block.Biome;
 import org.bukkit.block.data.BlockData;
@@ -518,6 +521,24 @@ public class NMSBinding implements INMSBinding {
     @Override
     public Entity spawnEntity(Location location,  org.bukkit.entity.EntityType type, CreatureSpawnEvent.SpawnReason reason) {
         return ((CraftWorld) location.getWorld()).spawn(location, type.getEntityClass(), null, reason);
+    }
+
+    @Override
+    public Color getBiomeColor(Location location, BiomeColor type) {
+        LevelReader reader = ((CraftWorld) location.getWorld()).getHandle();
+        var holder = reader.getBiome(new BlockPos(location.getBlockX(), location.getBlockY(), location.getBlockZ()));
+        var biome = holder.value();
+        if (biome == null) throw new IllegalArgumentException("Invalid biome: " + holder.unwrapKey().orElse(null));
+
+        int rgba = switch (type) {
+            case FOG -> biome.getFogColor();
+            case WATER -> biome.getWaterColor();
+            case WATER_FOG -> biome.getWaterFogColor();
+            case SKY -> biome.getSkyColor();
+            case FOLIAGE -> biome.getFoliageColor();
+            case GRASS -> biome.getGrassColor(location.getBlockX(), location.getBlockZ());
+        };
+        return new Color(rgba, true);
     }
 
     private static Field getField(Class<?> clazz, Class<?> fieldType) throws NoSuchFieldException {

--- a/nms/v1_20_R3/src/main/java/com/volmit/iris/core/nms/v1_20_R3/NMSBinding.java
+++ b/nms/v1_20_R3/src/main/java/com/volmit/iris/core/nms/v1_20_R3/NMSBinding.java
@@ -539,6 +539,12 @@ public class NMSBinding implements INMSBinding {
             case FOLIAGE -> biome.getFoliageColor();
             case GRASS -> biome.getGrassColor(location.getBlockX(), location.getBlockZ());
         };
+        if (rgba == 0) {
+            if (BiomeColor.FOLIAGE == type && biome.getSpecialEffects().getFoliageColorOverride().isEmpty())
+                return null;
+            if (BiomeColor.GRASS == type && biome.getSpecialEffects().getGrassColorOverride().isEmpty())
+                return null;
+        }
         return new Color(rgba, true);
     }
 

--- a/nms/v1_20_R3/src/main/java/com/volmit/iris/core/nms/v1_20_R3/NMSBinding.java
+++ b/nms/v1_20_R3/src/main/java/com/volmit/iris/core/nms/v1_20_R3/NMSBinding.java
@@ -1,5 +1,6 @@
 package com.volmit.iris.core.nms.v1_20_R3;
 
+import java.awt.Color;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
@@ -12,6 +13,8 @@ import java.util.List;
 import java.util.Vector;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import com.volmit.iris.core.nms.container.BiomeColor;
+import net.minecraft.world.level.LevelReader;
 import org.bukkit.*;
 import org.bukkit.block.Biome;
 import org.bukkit.block.data.BlockData;
@@ -519,6 +522,24 @@ public class NMSBinding implements INMSBinding {
     @Override
     public Entity spawnEntity(Location location,  org.bukkit.entity.EntityType type, CreatureSpawnEvent.SpawnReason reason) {
         return ((CraftWorld) location.getWorld()).spawn(location, type.getEntityClass(), null, reason);
+    }
+
+    @Override
+    public Color getBiomeColor(Location location, BiomeColor type) {
+        LevelReader reader = ((CraftWorld) location.getWorld()).getHandle();
+        var holder = reader.getBiome(new BlockPos(location.getBlockX(), location.getBlockY(), location.getBlockZ()));
+        var biome = holder.value();
+        if (biome == null) throw new IllegalArgumentException("Invalid biome: " + holder.unwrapKey().orElse(null));
+
+        int rgba = switch (type) {
+            case FOG -> biome.getFogColor();
+            case WATER -> biome.getWaterColor();
+            case WATER_FOG -> biome.getWaterFogColor();
+            case SKY -> biome.getSkyColor();
+            case FOLIAGE -> biome.getFoliageColor();
+            case GRASS -> biome.getGrassColor(location.getBlockX(), location.getBlockZ());
+        };
+        return new Color(rgba, true);
     }
 
     private static Field getField(Class<?> clazz, Class<?> fieldType) throws NoSuchFieldException {

--- a/nms/v1_20_R4/src/main/java/com/volmit/iris/core/nms/v1_20_R4/NMSBinding.java
+++ b/nms/v1_20_R4/src/main/java/com/volmit/iris/core/nms/v1_20_R4/NMSBinding.java
@@ -542,6 +542,12 @@ public class NMSBinding implements INMSBinding {
             case FOLIAGE -> biome.getFoliageColor();
             case GRASS -> biome.getGrassColor(location.getBlockX(), location.getBlockZ());
         };
+        if (rgba == 0) {
+            if (BiomeColor.FOLIAGE == type && biome.getSpecialEffects().getFoliageColorOverride().isEmpty())
+                return null;
+            if (BiomeColor.GRASS == type && biome.getSpecialEffects().getGrassColorOverride().isEmpty())
+                return null;
+        }
         return new Color(rgba, true);
     }
 

--- a/nms/v1_20_R4/src/main/java/com/volmit/iris/core/nms/v1_20_R4/NMSBinding.java
+++ b/nms/v1_20_R4/src/main/java/com/volmit/iris/core/nms/v1_20_R4/NMSBinding.java
@@ -1,5 +1,6 @@
 package com.volmit.iris.core.nms.v1_20_R4;
 
+import java.awt.Color;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
@@ -12,9 +13,11 @@ import java.util.List;
 import java.util.Vector;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import com.volmit.iris.core.nms.container.BiomeColor;
 import com.volmit.iris.core.nms.datapack.DataVersion;
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.world.item.component.CustomData;
+import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.chunk.status.ChunkStatus;
 import org.bukkit.*;
 import org.bukkit.block.Biome;
@@ -522,6 +525,24 @@ public class NMSBinding implements INMSBinding {
     @Override
     public Entity spawnEntity(Location location,  org.bukkit.entity.EntityType type, CreatureSpawnEvent.SpawnReason reason) {
         return ((CraftWorld) location.getWorld()).spawn(location, type.getEntityClass(), null, reason);
+    }
+
+    @Override
+    public Color getBiomeColor(Location location, BiomeColor type) {
+        LevelReader reader = ((CraftWorld) location.getWorld()).getHandle();
+        var holder = reader.getBiome(new BlockPos(location.getBlockX(), location.getBlockY(), location.getBlockZ()));
+        var biome = holder.value();
+        if (biome == null) throw new IllegalArgumentException("Invalid biome: " + holder.unwrapKey().orElse(null));
+
+        int rgba = switch (type) {
+            case FOG -> biome.getFogColor();
+            case WATER -> biome.getWaterColor();
+            case WATER_FOG -> biome.getWaterFogColor();
+            case SKY -> biome.getSkyColor();
+            case FOLIAGE -> biome.getFoliageColor();
+            case GRASS -> biome.getGrassColor(location.getBlockX(), location.getBlockZ());
+        };
+        return new Color(rgba, true);
     }
 
     private static Field getField(Class<?> clazz, Class<?> fieldType) throws NoSuchFieldException {


### PR DESCRIPTION
Added additional options to oraxen furniture blocks:

matchBiome:
> - FOG
> - WATER
> - WATER_FOG
> - SKY
> - FOLIAGE
> - GRASS

randomFace: (default false)
> - true
> - false

face: (default NORTH)
> - NORTH
> - NORTH_EAST
> - NORTH_NORTH_EAST
> - EAST
> - EAST_SOUTH_EAST
> - SOUTH_EAST
> - SOUTH_SOUTH_EAST
> - SOUTH
> - SOUTH_SOUTH_WEST
> - SOUTH_WEST
> - WEST_SOUTH_WEST
> - WEST
> - WEST_NORTH_WEST
> - NORTH_WEST
> - NORTH_NORTH_WEST
> - UP
> - DOWN

randomYaw: (default false)
> - true
> - false

yaw: (default 0)
> any number from 0 to 360

example
```json
        {
            "chance": 0.02,
            "variance": {"style": "STATIC"},
            "zoom": 0.2,
            "palette": [{
                "block": "oraxen:plant_1",
                "data": {
                    "matchBiome": "GRASS",
                    "randomYaw": "true",
                    "randomFace": "true"
                }
            }]
        }
```
