### PR TITLE
3.7.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -105,7 +105,7 @@ nmsBindings.forEach { key, value ->
         pluginJars(tasks.jar.flatMap { it.archiveFile })
         javaLauncher = javaToolchains.launcherFor { languageVersion = JavaLanguageVersion.of(jvmVersion.getOrDefault(key, 21))}
         runDirectory.convention(layout.buildDirectory.dir("run/$key"))
-        systemProperty("disable.watchdog", "")
+        systemProperty("disable.watchdog", "true")
         systemProperty("net.kyori.ansi.colorLevel", color)
         systemProperty("com.mojang.eula.agree", true)
         systemProperty("iris.suppressReporting", !errorReporting)

--- a/core/src/main/java/com/volmit/iris/core/IrisSettings.java
+++ b/core/src/main/java/com/volmit/iris/core/IrisSettings.java
@@ -176,13 +176,13 @@ public class IrisSettings {
 
     @Data
     public static class IrisSettingsUpdater {
-        public double threadMultiplier = 2;
+        public int maxConcurrency = 256;
         public double chunkLoadSensitivity = 0.7;
         public MsRange emptyMsRange = new MsRange(80, 100);
         public MsRange defaultMsRange = new MsRange(20, 40);
 
-        public double getThreadMultiplier() {
-            return Math.min(Math.abs(threadMultiplier), 0.1);
+        public int getMaxConcurrency() {
+            return Math.max(Math.abs(maxConcurrency), 1);
         }
 
         public double getChunkLoadSensitivity() {

--- a/core/src/main/java/com/volmit/iris/core/IrisSettings.java
+++ b/core/src/main/java/com/volmit/iris/core/IrisSettings.java
@@ -242,6 +242,7 @@ public class IrisSettings {
         public String defaultWorldType = "overworld";
         public int maxBiomeChildDepth = 4;
         public boolean preventLeafDecay = true;
+        public boolean useMulticore = false;
     }
 
     @Data
@@ -255,6 +256,7 @@ public class IrisSettings {
     @Data
     public static class IrisSettingsEngineSVC {
         public boolean useVirtualThreads = true;
+        public boolean forceMulticoreWrite = false;
         public int priority = Thread.NORM_PRIORITY;
 
         public int getPriority() {

--- a/core/src/main/java/com/volmit/iris/core/commands/CommandDeveloper.java
+++ b/core/src/main/java/com/volmit/iris/core/commands/CommandDeveloper.java
@@ -116,27 +116,6 @@ public class CommandDeveloper implements DecreeExecutor {
     }
 
     @Decree(description = "Test")
-    public void benchmarkMantle(
-            @Param(description = "The world to bench", aliases = {"world"})
-            World world
-    ) throws IOException, ClassNotFoundException {
-        Engine engine = IrisToolbelt.access(world).getEngine();
-        int maxHeight = engine.getTarget().getHeight();
-        File folder = new File(Bukkit.getWorldContainer(), world.getName());
-        int c = 0;
-        //MCAUtil.read()
-
-        File tectonicplates = new File(folder, "mantle");
-        for (File i : Objects.requireNonNull(tectonicplates.listFiles())) {
-            TectonicPlate.read(maxHeight, i, true);
-            c++;
-            Iris.info("Loaded count: " + c );
-
-        }
-
-    }
-
-    @Decree(description = "Test")
     public void packBenchmark(
             @Param(description = "The pack to bench", aliases = {"pack"}, defaultValue = "overworld")
             IrisDimension dimension,

--- a/core/src/main/java/com/volmit/iris/core/commands/CommandDeveloper.java
+++ b/core/src/main/java/com/volmit/iris/core/commands/CommandDeveloper.java
@@ -37,6 +37,7 @@ import com.volmit.iris.util.io.CountingDataInputStream;
 import com.volmit.iris.util.io.IO;
 import com.volmit.iris.util.mantle.TectonicPlate;
 import com.volmit.iris.util.math.M;
+import com.volmit.iris.util.matter.Matter;
 import com.volmit.iris.util.nbt.mca.MCAFile;
 import com.volmit.iris.util.nbt.mca.MCAUtil;
 import com.volmit.iris.util.parallel.MultiBurst;
@@ -53,6 +54,7 @@ import org.bukkit.World;
 import java.io.*;
 import java.net.InetAddress;
 import java.net.NetworkInterface;
+import java.nio.file.Files;
 import java.util.*;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -76,6 +78,33 @@ public class CommandDeveloper implements DecreeExecutor {
         Engine engine = engine();
         if (engine != null) IrisContext.getOr(engine);
         Iris.reportError(new Exception("This is a test"));
+    }
+
+    @Decree(description = "Test")
+    public void mantle(@Param(defaultValue = "false") boolean plate, @Param(defaultValue = "21474836474") String name) throws Throwable {
+        var base = Iris.instance.getDataFile("dump", "pv." + name + ".ttp.lz4b.bin");
+        var section = Iris.instance.getDataFile("dump", "pv." + name + ".section.bin");
+
+        //extractSection(base, section, 5604930, 4397);
+
+        if (plate) {
+            try (var in = CountingDataInputStream.wrap(new BufferedInputStream(new FileInputStream(base)))) {
+                new TectonicPlate(1088, in, true);
+            } catch (Throwable e) {
+                e.printStackTrace();
+            }
+        } else Matter.read(section);
+        if (!TectonicPlate.hasError())
+            Iris.info("Read " + (plate ? base : section).length() + " bytes from " + (plate ? base : section).getAbsolutePath());
+    }
+
+    private void extractSection(File source, File target, long offset, int length) throws IOException {
+        var raf = new RandomAccessFile(source, "r");
+        var bytes = new byte[length];
+        raf.seek(offset);
+        raf.readFully(bytes);
+        raf.close();
+        Files.write(target.toPath(), bytes);
     }
 
     @Decree(description = "Test")

--- a/core/src/main/java/com/volmit/iris/core/commands/CommandDeveloper.java
+++ b/core/src/main/java/com/volmit/iris/core/commands/CommandDeveloper.java
@@ -64,7 +64,6 @@ import java.util.zip.GZIPOutputStream;
 public class CommandDeveloper implements DecreeExecutor {
     private CommandTurboPregen turboPregen;
     private CommandLazyPregen lazyPregen;
-    private CommandUpdater updater;
 
     @Decree(description = "Get Loaded TectonicPlates Count", origin = DecreeOrigin.BOTH, sync = true)
     public void EngineStatus() {

--- a/core/src/main/java/com/volmit/iris/core/commands/CommandIris.java
+++ b/core/src/main/java/com/volmit/iris/core/commands/CommandIris.java
@@ -21,7 +21,6 @@ package com.volmit.iris.core.commands;
 import com.volmit.iris.Iris;
 import com.volmit.iris.core.IrisSettings;
 import com.volmit.iris.core.nms.INMS;
-import com.volmit.iris.core.pregenerator.ChunkUpdater;
 import com.volmit.iris.core.service.StudioSVC;
 import com.volmit.iris.core.tools.IrisToolbelt;
 import com.volmit.iris.engine.framework.Engine;
@@ -33,7 +32,6 @@ import com.volmit.iris.util.decree.annotations.Decree;
 import com.volmit.iris.util.decree.annotations.Param;
 import com.volmit.iris.util.decree.specialhandlers.NullablePlayerHandler;
 import com.volmit.iris.util.format.C;
-import com.volmit.iris.util.format.Form;
 import com.volmit.iris.util.io.IO;
 import com.volmit.iris.util.misc.ServerProperties;
 import com.volmit.iris.util.plugin.VolmitSender;
@@ -56,6 +54,7 @@ import static org.bukkit.Bukkit.getServer;
 
 @Decree(name = "iris", aliases = {"ir", "irs"}, description = "Basic Command")
 public class CommandIris implements DecreeExecutor {
+    private CommandUpdater updater;
     private CommandStudio studio;
     private CommandPregen pregen;
     private CommandSettings settings;
@@ -316,24 +315,6 @@ public class CommandIris implements DecreeExecutor {
             }
         }
         return dir.delete();
-    }
-
-    @Decree(description = "Updates all chunk in the specified world")
-    public void updater(
-            @Param(description = "World to update chunks at")
-            World world
-    ) {
-        if (!IrisToolbelt.isIrisWorld(world)) {
-            sender().sendMessage(C.GOLD + "This is not an Iris world");
-            return;
-        }
-        ChunkUpdater updater = new ChunkUpdater(world);
-        if (sender().isPlayer()) {
-            sender().sendMessage(C.GREEN + "Updating " + world.getName() + " Total chunks: " + Form.f(updater.getChunks()));
-        } else {
-            Iris.info(C.GREEN + "Updating " + world.getName() + " Total chunks: " + Form.f(updater.getChunks()));
-        }
-        updater.start();
     }
 
     @Decree(description = "Set aura spins")

--- a/core/src/main/java/com/volmit/iris/core/commands/CommandStudio.java
+++ b/core/src/main/java/com/volmit/iris/core/commands/CommandStudio.java
@@ -182,17 +182,32 @@ public class CommandStudio implements DecreeExecutor {
                 int rad = engine.getMantle().getRadius();
                 var mantle = engine.getMantle().getMantle();
                 var chunkMap = new KMap<Position2, MantleChunk>();
-                for (int i = -(radius + rad); i <= radius + rad; i++) {
-                    for (int j = -(radius + rad); j <= radius + rad; j++) {
-                        int xx = i + x, zz = j + z;
-                        if (Math.abs(i) <= radius && Math.abs(j) <= radius) {
-                            mantle.deleteChunk(xx, zz);
-                            continue;
+                ParallelQueueJob<Position2> prep = new ParallelQueueJob<>() {
+                    @Override
+                    public void execute(Position2 pos) {
+                        var cpos = pos.add(x, z);
+                        if (Math.abs(pos.getX()) <= radius && Math.abs(pos.getZ()) <= radius) {
+                            mantle.deleteChunk(cpos.getX(), cpos.getZ());
+                            return;
                         }
-                        chunkMap.put(new Position2(xx, zz), mantle.getChunk(xx, zz));
-                        mantle.deleteChunk(xx, zz);
+                        chunkMap.put(cpos, mantle.getChunk(cpos.getX(), cpos.getZ()));
+                        mantle.deleteChunk(cpos.getX(), cpos.getZ());
+                    }
+
+                    @Override
+                    public String getName() {
+                        return "Preparing Mantle";
+                    }
+                };
+                for (int xx = -(radius + rad); xx <= radius + rad; xx++) {
+                    for (int zz = -(radius + rad); zz <= radius + rad; zz++) {
+                        prep.queue(new Position2(xx, zz));
                     }
                 }
+                CountDownLatch pLatch = new CountDownLatch(1);
+                prep.execute(sender(), pLatch::countDown);
+                pLatch.await();
+
 
                 ParallelQueueJob<Position2> job = new ParallelQueueJob<>() {
                     @Override
@@ -210,23 +225,26 @@ public class CommandStudio implements DecreeExecutor {
                         job.queue(new Position2(i + x, j + z));
                     }
                 }
-
                 CountDownLatch latch = new CountDownLatch(1);
                 job.execute(sender(), latch::countDown);
                 latch.await();
 
                 int sections = mantle.getWorldHeight() >> 4;
                 chunkMap.forEach((pos, chunk) -> {
-                    var c = mantle.getChunk(pos.getX(), pos.getZ());
-                    for (MantleFlag flag : MantleFlag.values()) {
-                        c.flag(flag, chunk.isFlagged(flag));
-                    }
-                    c.clear();
-                    for (int y = 0; y < sections; y++) {
-                        var slice = chunk.get(y);
-                        if (slice == null) continue;
-                        var s = c.getOrCreate(y);
-                        slice.getSliceMap().forEach(s::putSlice);
+                    var c = mantle.getChunk(pos.getX(), pos.getZ()).use();
+                    try {
+                        for (MantleFlag flag : MantleFlag.values()) {
+                            c.flag(flag, chunk.isFlagged(flag));
+                        }
+                        c.clear();
+                        for (int y = 0; y < sections; y++) {
+                            var slice = chunk.get(y);
+                            if (slice == null) continue;
+                            var s = c.getOrCreate(y);
+                            slice.getSliceMap().forEach(s::putSlice);
+                        }
+                    } finally {
+                        c.release();
                     }
                 });
             } catch (Throwable e) {

--- a/core/src/main/java/com/volmit/iris/core/link/data/NexoDataProvider.java
+++ b/core/src/main/java/com/volmit/iris/core/link/data/NexoDataProvider.java
@@ -26,11 +26,8 @@ import org.jetbrains.annotations.NotNull;
 import java.util.Collection;
 import java.util.List;
 import java.util.MissingResourceException;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 public class NexoDataProvider extends ExternalDataProvider {
-    private final AtomicBoolean failed = new AtomicBoolean(false);
-
     public NexoDataProvider() {
         super("Nexo");
     }
@@ -124,10 +121,5 @@ public class NexoDataProvider extends ExternalDataProvider {
     public boolean isValidProvider(@NotNull Identifier id, DataType dataType) {
         if (dataType == DataType.ENTITY) return false;
         return "nexo".equalsIgnoreCase(id.namespace());
-    }
-
-    @Override
-    public boolean isReady() {
-        return super.isReady() && !failed.get();
     }
 }

--- a/core/src/main/java/com/volmit/iris/core/loader/ResourceLoader.java
+++ b/core/src/main/java/com/volmit/iris/core/loader/ResourceLoader.java
@@ -23,6 +23,7 @@ import com.volmit.iris.Iris;
 import com.volmit.iris.core.IrisSettings;
 import com.volmit.iris.core.project.SchemaBuilder;
 import com.volmit.iris.core.service.PreservationSVC;
+import com.volmit.iris.engine.data.cache.AtomicCache;
 import com.volmit.iris.engine.framework.Engine;
 import com.volmit.iris.engine.framework.MeteredCache;
 import com.volmit.iris.util.collection.KList;
@@ -45,9 +46,7 @@ import lombok.ToString;
 
 import java.io.*;
 import java.util.Locale;
-import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
@@ -60,7 +59,7 @@ import java.util.zip.GZIPOutputStream;
 public class ResourceLoader<T extends IrisRegistrant> implements MeteredCache {
     public static final AtomicDouble tlt = new AtomicDouble(0);
     private static final int CACHE_SIZE = 100000;
-    protected final AtomicReference<KList<File>> folderCache;
+    protected final AtomicCache<KList<File>> folderCache;
     protected KSet<String> firstAccess;
     protected File root;
     protected String folderName;
@@ -76,7 +75,7 @@ public class ResourceLoader<T extends IrisRegistrant> implements MeteredCache {
     public ResourceLoader(File root, IrisData manager, String folderName, String resourceTypeName, Class<? extends T> objectClass) {
         this.manager = manager;
         firstAccess = new KSet<>();
-        folderCache = new AtomicReference<>();
+        folderCache = new AtomicCache<>();
         sec = new ChronoLatch(5000);
         loads = new AtomicInteger();
         this.objectClass = objectClass;
@@ -361,29 +360,24 @@ public class ResourceLoader<T extends IrisRegistrant> implements MeteredCache {
     }
 
     public KList<File> getFolders() {
-        synchronized (folderCache) {
-            if (folderCache.get() == null) {
-                KList<File> fc = new KList<>();
+        return folderCache.aquire(() -> {
+            KList<File> fc = new KList<>();
 
-                File[] files = root.listFiles();
-                if (files == null) {
-                    throw new IllegalStateException("Failed to list files in " + root);
-                }
+            File[] files = root.listFiles();
+            if (files == null) {
+                throw new IllegalStateException("Failed to list files in " + root);
+            }
 
-                for (File i : files) {
-                    if (i.isDirectory()) {
-                        if (i.getName().equals(folderName)) {
-                            fc.add(i);
-                            break;
-                        }
+            for (File i : files) {
+                if (i.isDirectory()) {
+                    if (i.getName().equals(folderName)) {
+                        fc.add(i);
+                        break;
                     }
                 }
-
-                folderCache.set(fc);
             }
-        }
-
-        return folderCache.get();
+            return fc;
+        });
     }
 
     public KList<File> getFolders(String rc) {
@@ -403,7 +397,7 @@ public class ResourceLoader<T extends IrisRegistrant> implements MeteredCache {
     public void clearCache() {
         possibleKeys = null;
         loadCache.invalidate();
-        folderCache.set(null);
+        folderCache.reset();
     }
 
     public File fileFor(T b) {
@@ -429,7 +423,7 @@ public class ResourceLoader<T extends IrisRegistrant> implements MeteredCache {
     }
 
     public void clearList() {
-        folderCache.set(null);
+        folderCache.reset();
         possibleKeys = null;
     }
 

--- a/core/src/main/java/com/volmit/iris/core/pregenerator/ChunkUpdater.java
+++ b/core/src/main/java/com/volmit/iris/core/pregenerator/ChunkUpdater.java
@@ -39,14 +39,14 @@ public class ChunkUpdater {
     private final AtomicInteger chunksUpdated = new AtomicInteger();
     private final AtomicBoolean serverEmpty = new AtomicBoolean(true);
     private final AtomicLong lastCpsTime = new AtomicLong(M.ms());
-    private final int coreLimit = (int) Math.max(Runtime.getRuntime().availableProcessors() * IrisSettings.get().getUpdater().getThreadMultiplier(), 1);
-    private final Semaphore semaphore = new Semaphore(256);
-    private final LoadBalancer loadBalancer = new LoadBalancer(semaphore, 256, IrisSettings.get().getUpdater().emptyMsRange);
+    private final int maxConcurrency = IrisSettings.get().getUpdater().getMaxConcurrency();
+    private final Semaphore semaphore = new Semaphore(maxConcurrency);
+    private final LoadBalancer loadBalancer = new LoadBalancer(semaphore, maxConcurrency, IrisSettings.get().getUpdater().emptyMsRange);
     private final AtomicLong startTime = new AtomicLong();
     private final Dimensions dimensions;
     private final PregenTask task;
-    private final ExecutorService executor = Executors.newFixedThreadPool(coreLimit);
-    private final ExecutorService chunkExecutor = Executors.newFixedThreadPool(coreLimit);
+    private final ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor();
+    private final ExecutorService chunkExecutor = Executors.newVirtualThreadPerTaskExecutor();
     private final ScheduledExecutorService scheduler  = Executors.newScheduledThreadPool(1);
     private final CountDownLatch latch;
     private final Engine engine;
@@ -138,10 +138,10 @@ public class ChunkUpdater {
             loadBalancer.close();
             semaphore.acquire(256);
 
-            executor.shutdown();
-            executor.awaitTermination(5, TimeUnit.SECONDS);
             chunkExecutor.shutdown();
             chunkExecutor.awaitTermination(5, TimeUnit.SECONDS);
+            executor.shutdown();
+            executor.awaitTermination(5, TimeUnit.SECONDS);
             scheduler.shutdownNow();
             unloadAndSaveAllChunks();
         } catch (Exception ignored) {}

--- a/core/src/main/java/com/volmit/iris/core/service/ExternalDataSVC.java
+++ b/core/src/main/java/com/volmit/iris/core/service/ExternalDataSVC.java
@@ -69,8 +69,8 @@ public class ExternalDataSVC implements IrisService {
 
     @EventHandler
     public void onPluginEnable(PluginEnableEvent e) {
-        if (activeProviders.stream().noneMatch(p -> p.getPlugin().equals(e.getPlugin()))) {
-            providers.stream().filter(p -> p.isReady() && p.getPlugin().equals(e.getPlugin())).findFirst().ifPresent(edp -> {
+        if (activeProviders.stream().noneMatch(p -> e.getPlugin().equals(p.getPlugin()))) {
+            providers.stream().filter(p -> p.isReady() && e.getPlugin().equals(p.getPlugin())).findFirst().ifPresent(edp -> {
                 activeProviders.add(edp);
                 edp.init();
                 Iris.instance.registerListener(edp);

--- a/core/src/main/java/com/volmit/iris/core/service/IrisEngineSVC.java
+++ b/core/src/main/java/com/volmit/iris/core/service/IrisEngineSVC.java
@@ -205,7 +205,7 @@ public class IrisEngineSVC implements IrisService {
 
                     try {
                         long unloadStart = System.currentTimeMillis();
-                        int count = engine.getMantle().unloadTectonicPlate(tectonicLimit());
+                        int count = engine.getMantle().unloadTectonicPlate(IrisSettings.get().getPerformance().getEngineSVC().forceMulticoreWrite ? 0 : tectonicLimit());
                         if (count > 0) {
                             Iris.debug(C.GOLD + "Unloaded " + C.YELLOW + count + " TectonicPlates in " + C.RED + Form.duration(System.currentTimeMillis() - unloadStart, 2));
                         }

--- a/core/src/main/java/com/volmit/iris/core/service/IrisEngineSVC.java
+++ b/core/src/main/java/com/volmit/iris/core/service/IrisEngineSVC.java
@@ -157,6 +157,7 @@ public class IrisEngineSVC implements IrisService {
     private final class Registered {
         private final String name;
         private final PlatformChunkGenerator access;
+        private final int offset = RNG.r.nextInt(1000);
         private transient ScheduledFuture<?> trimmer;
         private transient ScheduledFuture<?> unloader;
         private transient boolean closed;
@@ -193,7 +194,7 @@ public class IrisEngineSVC implements IrisService {
                         Iris.error("EngineSVC: Failed to trim for " + name);
                         e.printStackTrace();
                     }
-                }, RNG.r.nextInt(1000), 1000, TimeUnit.MILLISECONDS);
+                }, offset, 2000, TimeUnit.MILLISECONDS);
             }
 
             if (unloader == null || unloader.isDone() || unloader.isCancelled()) {
@@ -213,7 +214,7 @@ public class IrisEngineSVC implements IrisService {
                         Iris.error("EngineSVC: Failed to unload for " + name);
                         e.printStackTrace();
                     }
-                }, RNG.r.nextInt(1000), 1000, TimeUnit.MILLISECONDS);
+                }, offset + 1000, 2000, TimeUnit.MILLISECONDS);
             }
         }
 

--- a/core/src/main/java/com/volmit/iris/engine/framework/Engine.java
+++ b/core/src/main/java/com/volmit/iris/engine/framework/Engine.java
@@ -296,67 +296,63 @@ public interface Engine extends DataProvider, Fallible, LootProvider, BlockUpdat
         try {
             Semaphore semaphore = new Semaphore(3);
             chunk.raiseFlag(MantleFlag.ETCHED, () -> {
-                chunk.raiseFlag(MantleFlag.TILE, run(semaphore, () -> J.s(() -> {
-                    mantle.iterateChunk(c.getX(), c.getZ(), TileWrapper.class, (x, y, z, v) -> {
-                        int betterY = y + getWorld().minHeight();
-                        if (!TileData.setTileState(c.getBlock(x, betterY, z), v.getData()))
-                            Iris.warn("Failed to set tile entity data at [%d %d %d | %s] for tile %s!", x, betterY, z, c.getBlock(x, betterY, z).getBlockData().getMaterial().getKey(), v.getData().getMaterial().name());
+                chunk.raiseFlag(MantleFlag.TILE, run(semaphore, () -> {
+                    chunk.iterate(TileWrapper.class, (x, y, z, v) -> {
+                        Block block = c.getBlock(x & 15, y + getWorld().minHeight(), z & 15);
+                        if (!TileData.setTileState(block, v.getData()))
+                            Iris.warn("Failed to set tile entity data at [%d %d %d | %s] for tile %s!", block.getX(), block.getY(), block.getZ(), block.getType().getKey(), v.getData().getMaterial().getKey());
                     });
-                })));
-                chunk.raiseFlag(MantleFlag.CUSTOM, run(semaphore, () -> J.s(() -> {
-                    mantle.iterateChunk(c.getX(), c.getZ(), Identifier.class, (x, y, z, v) -> {
+                }, 0));
+                chunk.raiseFlag(MantleFlag.CUSTOM, run(semaphore, () -> {
+                    chunk.iterate(Identifier.class, (x, y, z, v) -> {
                         Iris.service(ExternalDataSVC.class).processUpdate(this, c.getBlock(x & 15, y + getWorld().minHeight(), z & 15), v);
                     });
-                })));
+                }, 0));
 
-                chunk.raiseFlag(MantleFlag.UPDATE, run(semaphore, () -> J.s(() -> {
+                chunk.raiseFlag(MantleFlag.UPDATE, run(semaphore, () -> {
                     PrecisionStopwatch p = PrecisionStopwatch.start();
-                    KMap<Long, Integer> updates = new KMap<>();
-                    RNG r = new RNG(Cache.key(c.getX(), c.getZ()));
-                    mantle.iterateChunk(c.getX(), c.getZ(), MatterCavern.class, (x, yf, z, v) -> {
+                    int[][] grid = new int[16][16];
+                    for (int x = 0; x < 16; x++) {
+                        for (int z = 0; z < 16; z++) {
+                            grid[x][z] = Integer.MIN_VALUE;
+                        }
+                    }
+
+                    RNG rng = new RNG(Cache.key(c.getX(), c.getZ()));
+                    chunk.iterate(MatterCavern.class, (x, yf, z, v) -> {
                         int y = yf + getWorld().minHeight();
-                        if (!B.isFluid(c.getBlock(x & 15, y, z & 15).getBlockData())) {
+                        x &= 15;
+                        z &= 15;
+                        Block block = c.getBlock(x, y, z);
+                        if (!B.isFluid(block.getBlockData())) {
                             return;
                         }
-                        boolean u = false;
-                        if (B.isAir(c.getBlock(x & 15, y, z & 15).getRelative(BlockFace.DOWN).getBlockData())) {
-                            u = true;
-                        } else if (B.isAir(c.getBlock(x & 15, y, z & 15).getRelative(BlockFace.WEST).getBlockData())) {
-                            u = true;
-                        } else if (B.isAir(c.getBlock(x & 15, y, z & 15).getRelative(BlockFace.EAST).getBlockData())) {
-                            u = true;
-                        } else if (B.isAir(c.getBlock(x & 15, y, z & 15).getRelative(BlockFace.SOUTH).getBlockData())) {
-                            u = true;
-                        } else if (B.isAir(c.getBlock(x & 15, y, z & 15).getRelative(BlockFace.NORTH).getBlockData())) {
-                            u = true;
-                        }
+                        boolean u = B.isAir(block.getRelative(BlockFace.DOWN).getBlockData())
+                                || B.isAir(block.getRelative(BlockFace.WEST).getBlockData())
+                                || B.isAir(block.getRelative(BlockFace.EAST).getBlockData())
+                                || B.isAir(block.getRelative(BlockFace.SOUTH).getBlockData())
+                                || B.isAir(block.getRelative(BlockFace.NORTH).getBlockData());
 
-                        if (u) {
-                            updates.compute(Cache.key(x & 15, z & 15), (k, vv) -> {
-                                if (vv != null) {
-                                    return Math.max(vv, y);
-                                }
-
-                                return y;
-                            });
-                        }
+                        if (u) grid[x][z] = Math.max(grid[x][z], y);
                     });
 
-                    updates.forEach((k, v) -> update(Cache.keyX(k), v, Cache.keyZ(k), c, r));
-                    mantle.iterateChunk(c.getX(), c.getZ(), MatterUpdate.class, (x, yf, z, v) -> {
+                    for (int x = 0; x < 16; x++) {
+                        for (int z = 0; z < 16; z++) {
+                            if (grid[x][z] == Integer.MIN_VALUE)
+                                continue;
+                            update(x, grid[x][z], z, c, rng);
+                        }
+                    }
+
+                    chunk.iterate(MatterUpdate.class, (x, yf, z, v) -> {
                         int y = yf + getWorld().minHeight();
                         if (v != null && v.isUpdate()) {
-                            int vx = x & 15;
-                            int vz = z & 15;
-                            update(x, y, z, c, new RNG(Cache.key(c.getX(), c.getZ())));
-                            if (vx > 0 && vx < 15 && vz > 0 && vz < 15) {
-                                updateLighting(x, y, z, c);
-                            }
+                            update(x, y, z, c, rng);
                         }
                     });
-                    mantle.deleteChunkSlice(c.getX(), c.getZ(), MatterUpdate.class);
+                    chunk.deleteSlices(MatterUpdate.class);
                     getMetrics().getUpdates().put(p.getMilliseconds());
-                }, RNG.r.i(0, 20))));
+                }, RNG.r.i(1, 20))); //Why is there a random delay here?
             });
 
             try {
@@ -367,31 +363,19 @@ public interface Engine extends DataProvider, Fallible, LootProvider, BlockUpdat
         }
     }
 
-    private static Runnable run(Semaphore semaphore, Runnable runnable) {
+    private static Runnable run(Semaphore semaphore, Runnable runnable, int delay) {
         return () -> {
             if (!semaphore.tryAcquire())
                 return;
-            try {
-                runnable.run();
-            } finally {
-                semaphore.release();
-            }
+
+            J.s(() -> {
+                try {
+                    runnable.run();
+                } finally {
+                    semaphore.release();
+                }
+            }, delay);
         };
-    }
-
-    @BlockCoordinates
-    default void updateLighting(int x, int y, int z, Chunk c) {
-        Block block = c.getBlock(x, y, z);
-        BlockData data = block.getBlockData();
-
-        if (B.isLit(data)) {
-            try {
-                block.setType(Material.AIR, false);
-                block.setBlockData(data, true);
-            } catch (Exception e) {
-                Iris.reportError(e);
-            }
-        }
     }
 
     @BlockCoordinates

--- a/core/src/main/java/com/volmit/iris/engine/mantle/EngineMantle.java
+++ b/core/src/main/java/com/volmit/iris/engine/mantle/EngineMantle.java
@@ -26,31 +26,30 @@ import com.volmit.iris.engine.framework.Engine;
 import com.volmit.iris.engine.framework.EngineTarget;
 import com.volmit.iris.engine.mantle.components.MantleJigsawComponent;
 import com.volmit.iris.engine.mantle.components.MantleObjectComponent;
-import com.volmit.iris.engine.object.IObjectPlacer;
 import com.volmit.iris.engine.object.IrisDimension;
 import com.volmit.iris.engine.object.IrisPosition;
-import com.volmit.iris.engine.object.TileData;
 import com.volmit.iris.util.collection.KList;
 import com.volmit.iris.util.context.ChunkContext;
 import com.volmit.iris.util.context.IrisContext;
 import com.volmit.iris.util.data.B;
-import com.volmit.iris.util.data.IrisCustomData;
 import com.volmit.iris.util.documentation.BlockCoordinates;
 import com.volmit.iris.util.documentation.ChunkCoordinates;
 import com.volmit.iris.util.hunk.Hunk;
 import com.volmit.iris.util.mantle.Mantle;
 import com.volmit.iris.util.mantle.MantleChunk;
 import com.volmit.iris.util.mantle.MantleFlag;
+import com.volmit.iris.util.math.Position2;
 import com.volmit.iris.util.matter.*;
 import com.volmit.iris.util.matter.slices.UpdateMatter;
-import com.volmit.iris.util.parallel.BurstExecutor;
 import com.volmit.iris.util.parallel.MultiBurst;
 import org.bukkit.block.data.BlockData;
 
 import java.util.concurrent.TimeUnit;
 
-// TODO: MOVE PLACER OUT OF MATTER INTO ITS OWN THING
-public interface EngineMantle extends IObjectPlacer {
+import static com.volmit.iris.util.parallel.StreamUtils.forEach;
+import static com.volmit.iris.util.parallel.StreamUtils.streamRadius;
+
+public interface EngineMantle {
     BlockData AIR = B.get("AIR");
 
     Mantle getMantle();
@@ -87,12 +86,10 @@ public interface EngineMantle extends IObjectPlacer {
         return getHighest(x, z, getData(), ignoreFluid);
     }
 
-    @Override
     default int getHighest(int x, int z, IrisData data) {
         return getHighest(x, z, data, false);
     }
 
-    @Override
     default int getHighest(int x, int z, IrisData data, boolean ignoreFluid) {
         return ignoreFluid ? trueHeight(x, z) : Math.max(trueHeight(x, z), getEngine().getDimension().getFluidHeight());
     }
@@ -101,24 +98,12 @@ public interface EngineMantle extends IObjectPlacer {
         return getComplex().getRoundedHeighteightStream().get(x, z);
     }
 
+    @Deprecated(forRemoval = true)
     default boolean isCarved(int x, int h, int z) {
         return getMantle().get(x, h, z, MatterCavern.class) != null;
     }
 
-    @Override
-    default void set(int x, int y, int z, BlockData d) {
-        if (d instanceof IrisCustomData data) {
-            getMantle().set(x, y, z, data.getBase());
-            getMantle().set(x, y, z, data.getCustom());
-        } else getMantle().set(x, y, z, d == null ? AIR : d);
-    }
-
-    @Override
-    default void setTile(int x, int y, int z, TileData d) {
-        getMantle().set(x, y, z, new TileWrapper(d));
-    }
-
-    @Override
+    @Deprecated(forRemoval = true)
     default BlockData get(int x, int y, int z) {
         BlockData block = getMantle().get(x, y, z, BlockData.class);
         if (block == null)
@@ -126,27 +111,18 @@ public interface EngineMantle extends IObjectPlacer {
         return block;
     }
 
-    @Override
     default boolean isPreventingDecay() {
         return getEngine().getDimension().isPreventLeafDecay();
     }
 
-    @Override
-    default boolean isSolid(int x, int y, int z) {
-        return B.isSolid(get(x, y, z));
-    }
-
-    @Override
     default boolean isUnderwater(int x, int z) {
         return getHighest(x, z, true) <= getFluidHeight();
     }
 
-    @Override
     default int getFluidHeight() {
         return getEngine().getDimension().getFluidHeight();
     }
 
-    @Override
     default boolean isDebugSmartBore() {
         return getEngine().getDimension().isDebugSmartBore();
     }
@@ -206,32 +182,31 @@ public interface EngineMantle extends IObjectPlacer {
                 var pair = iterator.next();
                 int radius = pair.getB();
                 boolean last = !iterator.hasNext();
-                BurstExecutor burst = burst().burst((radius * 2 + 1) * pair.getA().size());
-                burst.setMulticore(multicore);
-
-                for (int i = -radius; i <= radius; i++) {
-                    for (int j = -radius; j <= radius; j++) {
-                        int xx = x + i;
-                        int zz = z + j;
-                        MantleChunk mc = getMantle().getChunk(xx, zz).use();
-                        for (MantleComponent c : pair.getA()) {
-                            burst.queue(() -> {
+                forEach(streamRadius(x, z, radius),
+                        pos -> pair.getA()
+                                .stream()
+                                .map(c -> new Pair<>(c, pos)),
+                        p -> {
+                            MantleComponent c = p.getA();
+                            Position2 pos = p.getB();
+                            int xx = pos.getX();
+                            int zz = pos.getZ();
+                            MantleChunk mc = getMantle().getChunk(xx, zz).use();
+                            try {
                                 IrisContext.getOr(getEngine()).setChunkContext(context);
                                 generateMantleComponent(writer, xx, zz, c, mc, context);
-                            });
-                        }
-                    }
-                }
+                            } finally {
+                                mc.release();
+                            }
+                        },
+                        multicore ? burst() : null
+                );
 
-                burst.complete();
-
-                for (int i = -radius; i <= radius; i++) {
-                    for (int j = -radius; j <= radius; j++) {
-                        var chunk = getMantle().getChunk(x + i, z + j);
-                        if (last) chunk.flag(MantleFlag.PLANNED, true);
-                        chunk.release();
-                    }
-                }
+                if (!last) continue;
+                forEach(streamRadius(x, z, radius),
+                        p -> getMantle().flag(p.getX(), p.getZ(), MantleFlag.PLANNED, true),
+                        multicore ? burst() : null
+                );
             }
         }
     }

--- a/core/src/main/java/com/volmit/iris/engine/mantle/EngineMantle.java
+++ b/core/src/main/java/com/volmit/iris/engine/mantle/EngineMantle.java
@@ -244,7 +244,12 @@ public interface EngineMantle extends IObjectPlacer {
             return;
         }
 
-        getMantle().iterateChunk(x, z, t, blocks::set);
+        var chunk = getMantle().getChunk(x, z).use();
+        try {
+            chunk.iterate(t, blocks::set);
+        } finally {
+            chunk.release();
+        }
     }
 
     @BlockCoordinates

--- a/core/src/main/java/com/volmit/iris/engine/mantle/EngineMantle.java
+++ b/core/src/main/java/com/volmit/iris/engine/mantle/EngineMantle.java
@@ -213,12 +213,16 @@ public interface EngineMantle extends IObjectPlacer {
                     for (int j = -radius; j <= radius; j++) {
                         int xx = x + i;
                         int zz = z + j;
-                        MantleChunk mc = getMantle().getChunk(xx, zz);
+                        MantleChunk mc = getMantle().getChunk(xx, zz).use();
 
                         burst.queue(() -> {
-                            IrisContext.touch(getEngine().getContext());
-                            pair.getA().forEach(k -> generateMantleComponent(writer, xx, zz, k, mc, context));
-                            if (last) mc.flag(MantleFlag.PLANNED, true);
+                            try {
+                                IrisContext.touch(getEngine().getContext());
+                                pair.getA().forEach(k -> generateMantleComponent(writer, xx, zz, k, mc, context));
+                                if (last) mc.flag(MantleFlag.PLANNED, true);
+                            } finally {
+                                mc.release();
+                            }
                         });
                     }
                 }

--- a/core/src/main/java/com/volmit/iris/engine/mantle/components/MantleJigsawComponent.java
+++ b/core/src/main/java/com/volmit/iris/engine/mantle/components/MantleJigsawComponent.java
@@ -180,6 +180,10 @@ public class MantleJigsawComponent extends IrisMantleComponent {
         var dimension = getDimension();
 
         KSet<String> structures = new KSet<>();
+        if (dimension.getStronghold() != null) {
+            structures.add(dimension.getStronghold());
+        }
+
         for (var placement : dimension.getJigsawStructures()) {
             structures.add(placement.getStructure());
         }

--- a/core/src/main/java/com/volmit/iris/engine/mantle/components/MantleJigsawComponent.java
+++ b/core/src/main/java/com/volmit/iris/engine/mantle/components/MantleJigsawComponent.java
@@ -47,7 +47,7 @@ public class MantleJigsawComponent extends IrisMantleComponent {
     private final CNG cng;
 
     public MantleJigsawComponent(EngineMantle engineMantle) {
-        super(engineMantle, MantleFlag.JIGSAW, 1);
+        super(engineMantle, MantleFlag.JIGSAW, 2);
         cng = NoiseStyle.STATIC.create(new RNG(jigsaw()));
     }
 

--- a/core/src/main/java/com/volmit/iris/engine/modifier/IrisCarveModifier.java
+++ b/core/src/main/java/com/volmit/iris/engine/modifier/IrisCarveModifier.java
@@ -27,6 +27,7 @@ import com.volmit.iris.util.collection.KList;
 import com.volmit.iris.util.collection.KMap;
 import com.volmit.iris.util.context.ChunkContext;
 import com.volmit.iris.util.data.B;
+import com.volmit.iris.util.documentation.ChunkCoordinates;
 import com.volmit.iris.util.function.Consumer4;
 import com.volmit.iris.util.hunk.Hunk;
 import com.volmit.iris.util.mantle.Mantle;
@@ -53,10 +54,11 @@ public class IrisCarveModifier extends EngineAssignedModifier<BlockData> {
     }
 
     @Override
+    @ChunkCoordinates
     public void onModify(int x, int z, Hunk<BlockData> output, boolean multicore, ChunkContext context) {
         PrecisionStopwatch p = PrecisionStopwatch.start();
         Mantle mantle = getEngine().getMantle().getMantle();
-        MantleChunk mc = getEngine().getMantle().getMantle().getChunk(x, z).use();
+        MantleChunk mc = mantle.getChunk(x, z).use();
         KMap<Long, KList<Integer>> positions = new KMap<>();
         KMap<IrisPosition, MatterCavern> walls = new KMap<>();
         Consumer4<Integer, Integer, Integer, MatterCavern> iterator = (xx, yy, zz, c) -> {
@@ -81,19 +83,19 @@ public class IrisCarveModifier extends EngineAssignedModifier<BlockData> {
 
             //todo: Fix chunk decoration not working on chunk's border
 
-            if (rz < 15 && mantle.get(xx, yy, zz + 1, MatterCavern.class) == null) {
+            if (rz < 15 && mc.get(xx, yy, zz + 1, MatterCavern.class) == null) {
                 walls.put(new IrisPosition(rx, yy, rz + 1), c);
             }
 
-            if (rx < 15 && mantle.get(xx + 1, yy, zz, MatterCavern.class) == null) {
+            if (rx < 15 && mc.get(xx + 1, yy, zz, MatterCavern.class) == null) {
                 walls.put(new IrisPosition(rx + 1, yy, rz), c);
             }
 
-            if (rz > 0 && mantle.get(xx, yy, zz - 1, MatterCavern.class) == null) {
+            if (rz > 0 && mc.get(xx, yy, zz - 1, MatterCavern.class) == null) {
                 walls.put(new IrisPosition(rx, yy, rz - 1), c);
             }
 
-            if (rx > 0 && mantle.get(xx - 1, yy, zz, MatterCavern.class) == null) {
+            if (rx > 0 && mc.get(xx - 1, yy, zz, MatterCavern.class) == null) {
                 walls.put(new IrisPosition(rx - 1, yy, rz), c);
             }
 

--- a/core/src/main/java/com/volmit/iris/engine/object/IrisObject.java
+++ b/core/src/main/java/com/volmit/iris/engine/object/IrisObject.java
@@ -514,9 +514,9 @@ public class IrisObject extends IrisRegistrant {
             max.setZ(Math.max(max.getZ(), i.getZ()));
         }
 
-        w = max.getBlockX() - min.getBlockX() + (min.getBlockX() <= 0 && max.getBlockX() >= 0 && min.getBlockX() != max.getBlockX() ? 1 : 0);
-        h = max.getBlockY() - min.getBlockY() + (min.getBlockY() <= 0 && max.getBlockY() >= 0 && min.getBlockY() != max.getBlockY() ? 1 : 0);
-        d = max.getBlockZ() - min.getBlockZ() + (min.getBlockZ() <= 0 && max.getBlockZ() >= 0 && min.getBlockZ() != max.getBlockZ() ? 1 : 0);
+        w = max.getBlockX() - min.getBlockX() + 1;
+        h = max.getBlockY() - min.getBlockY() + 1;
+        d = max.getBlockZ() - min.getBlockZ() + 1;
         center = new BlockVector(w / 2, h / 2, d / 2);
     }
 

--- a/core/src/main/java/com/volmit/iris/engine/platform/BukkitChunkGenerator.java
+++ b/core/src/main/java/com/volmit/iris/engine/platform/BukkitChunkGenerator.java
@@ -204,7 +204,7 @@ public class BukkitChunkGenerator extends ChunkGenerator implements PlatformChun
             IrisBiomeStorage st = new IrisBiomeStorage();
             TerrainChunk tc = TerrainChunk.createUnsafe(world, st);
             this.world.bind(world);
-            getEngine().generate(x << 4, z << 4, tc, false);
+            getEngine().generate(x << 4, z << 4, tc, IrisSettings.get().getGenerator().useMulticore);
 
             Chunk c = PaperLib.getChunkAtAsync(world, x, z)
                     .thenApply(d -> {

--- a/core/src/main/java/com/volmit/iris/engine/platform/BukkitChunkGenerator.java
+++ b/core/src/main/java/com/volmit/iris/engine/platform/BukkitChunkGenerator.java
@@ -19,6 +19,7 @@
 package com.volmit.iris.engine.platform;
 
 import com.volmit.iris.Iris;
+import com.volmit.iris.core.IrisSettings;
 import com.volmit.iris.core.IrisWorlds;
 import com.volmit.iris.core.loader.IrisData;
 import com.volmit.iris.core.nms.INMS;
@@ -34,7 +35,6 @@ import com.volmit.iris.engine.object.StudioMode;
 import com.volmit.iris.engine.platform.studio.StudioGenerator;
 import com.volmit.iris.util.collection.KList;
 import com.volmit.iris.util.data.IrisBiomeStorage;
-import com.volmit.iris.util.hunk.Hunk;
 import com.volmit.iris.util.hunk.view.BiomeGridHunkHolder;
 import com.volmit.iris.util.hunk.view.ChunkDataHunkHolder;
 import com.volmit.iris.util.io.ReactiveFolder;
@@ -46,8 +46,6 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.Setter;
 import org.bukkit.*;
-import org.bukkit.block.Biome;
-import org.bukkit.block.data.BlockData;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -367,7 +365,7 @@ public class BukkitChunkGenerator extends ChunkGenerator implements PlatformChun
             } else {
                 ChunkDataHunkHolder blocks = new ChunkDataHunkHolder(tc);
                 BiomeGridHunkHolder biomes = new BiomeGridHunkHolder(tc, tc.getMinHeight(), tc.getMaxHeight());
-                getEngine().generate(x << 4, z << 4, blocks, biomes, false);
+                getEngine().generate(x << 4, z << 4, blocks, biomes, IrisSettings.get().getGenerator().useMulticore);
                 blocks.apply();
                 biomes.apply();
             }

--- a/core/src/main/java/com/volmit/iris/util/data/B.java
+++ b/core/src/main/java/com/volmit/iris/util/data/B.java
@@ -610,8 +610,7 @@ public class B {
     }
 
     public static boolean isUpdatable(BlockData mat) {
-        return isLit(mat)
-                || isStorage(mat)
+        return isStorage(mat)
                 || (mat instanceof PointedDripstone
                 && ((PointedDripstone) mat).getThickness().equals(PointedDripstone.Thickness.TIP));
     }

--- a/core/src/main/java/com/volmit/iris/util/hunk/bits/DataBits.java
+++ b/core/src/main/java/com/volmit/iris/util/hunk/bits/DataBits.java
@@ -19,12 +19,12 @@
 package com.volmit.iris.util.hunk.bits;
 
 import com.volmit.iris.util.data.Varint;
+import lombok.Getter;
 import org.apache.commons.lang3.Validate;
 
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLongArray;
 import java.util.function.IntConsumer;
 
@@ -52,8 +52,10 @@ public class DataBits {
             0, 5};
 
     private final AtomicLongArray data;
+    @Getter
     private final int bits;
     private final long mask;
+    @Getter
     private final int size;
     private final int valuesPerLong;
     private final int divideMul;
@@ -149,18 +151,9 @@ public class DataBits {
         return data;
     }
 
-    public int getSize() {
-        return size;
-    }
-
-    public int getBits() {
-        return bits;
-    }
-
     public DataBits setBits(int newBits) {
         if (bits != newBits) {
             DataBits newData = new DataBits(newBits, size);
-            AtomicInteger c = new AtomicInteger(0);
 
             for (int i = 0; i < size; i++) {
                 newData.set(i, get(i));

--- a/core/src/main/java/com/volmit/iris/util/hunk/bits/LinearPalette.java
+++ b/core/src/main/java/com/volmit/iris/util/hunk/bits/LinearPalette.java
@@ -19,6 +19,7 @@
 package com.volmit.iris.util.hunk.bits;
 
 import com.volmit.iris.util.function.Consumer2;
+import lombok.Synchronized;
 
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReferenceArray;
@@ -87,7 +88,7 @@ public class LinearPalette<T> implements Palette<T> {
 
     @Override
     public void iterate(Consumer2<T, Integer> c) {
-        for (int i = 1; i < size() + 1; i++) {
+        for (int i = 1; i <= size(); i++) {
             c.accept(palette.get(i), i);
         }
     }

--- a/core/src/main/java/com/volmit/iris/util/io/CountingDataInputStream.java
+++ b/core/src/main/java/com/volmit/iris/util/io/CountingDataInputStream.java
@@ -44,14 +44,14 @@ public class CountingDataInputStream extends DataInputStream {
         }
 
         @Override
-        public int read(@NotNull byte[] b, int off, int len) throws IOException {
+        public int read(byte @NotNull [] b, int off, int len) throws IOException {
             int i = in.read(b, off, len);
-            count(i);
+            if (i != -1) count(i);
             return i;
         }
 
         private void count(int i) {
-            count += i;
+            count = Math.addExact(count, i);
             if (mark == -1)
                 return;
 
@@ -69,6 +69,12 @@ public class CountingDataInputStream extends DataInputStream {
         public synchronized void mark(int readlimit) {
             if (!in.markSupported()) return;
             in.mark(readlimit);
+            if (readlimit <= 0) {
+                mark = -1;
+                markLimit = 0;
+                return;
+            }
+
             mark = count;
             markLimit = readlimit;
         }

--- a/core/src/main/java/com/volmit/iris/util/io/IO.java
+++ b/core/src/main/java/com/volmit/iris/util/io/IO.java
@@ -24,14 +24,20 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.volmit.iris.Iris;
 import com.volmit.iris.util.format.Form;
+import com.volmit.iris.util.scheduling.J;
 import org.apache.commons.io.function.IOConsumer;
 import org.apache.commons.io.function.IOFunction;
 
 import java.io.*;
+import java.nio.channels.Channels;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.channels.OverlappingFileLockException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
 import java.security.DigestInputStream;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -1668,13 +1674,24 @@ public class IO {
         dir.mkdirs();
         dir.deleteOnExit();
         File temp = File.createTempFile("iris",".bin", dir);
-        try {
+        try (var target = FileChannel.open(file.toPath(), StandardOpenOption.READ, StandardOpenOption.WRITE, StandardOpenOption.CREATE, StandardOpenOption.SYNC)) {
+            lock(target);
+
             try (var out = builder.apply(new FileOutputStream(temp))) {
                 action.accept(out);
             }
-            Files.move(temp.toPath(), file.toPath(), StandardCopyOption.REPLACE_EXISTING);
+            Files.copy(temp.toPath(), Channels.newOutputStream(target));
         } finally {
             temp.delete();
+        }
+    }
+
+    public static FileLock lock(FileChannel channel) throws IOException {
+        while (true) {
+            try {
+                return channel.lock();
+            } catch (OverlappingFileLockException e) {}
+            J.sleep(1);
         }
     }
 }

--- a/core/src/main/java/com/volmit/iris/util/mantle/MantleChunk.java
+++ b/core/src/main/java/com/volmit/iris/util/mantle/MantleChunk.java
@@ -220,7 +220,9 @@ public class MantleChunk {
 
         if (matter == null) {
             matter = new IrisMatter(16, 16, 16);
-            sections.set(section, matter);
+            if (!sections.compareAndSet(section, null, matter)) {
+                matter = get(section);
+            }
         }
 
         return matter;

--- a/core/src/main/java/com/volmit/iris/util/mantle/MantleChunk.java
+++ b/core/src/main/java/com/volmit/iris/util/mantle/MantleChunk.java
@@ -109,6 +109,9 @@ public class MantleChunk {
                 din.skipTo(end);
                 TectonicPlate.addError();
             }
+            if (din.count() != start + size) {
+                throw new IOException("Chunk section read size mismatch!");
+            }
         }
     }
 

--- a/core/src/main/java/com/volmit/iris/util/mantle/TectonicPlate.java
+++ b/core/src/main/java/com/volmit/iris/util/mantle/TectonicPlate.java
@@ -19,26 +19,14 @@
 package com.volmit.iris.util.mantle;
 
 import com.volmit.iris.Iris;
-import com.volmit.iris.core.IrisSettings;
 import com.volmit.iris.engine.EnginePanic;
 import com.volmit.iris.engine.data.cache.Cache;
 import com.volmit.iris.util.data.Varint;
 import com.volmit.iris.util.documentation.ChunkCoordinates;
-import com.volmit.iris.util.format.C;
-import com.volmit.iris.util.format.Form;
 import com.volmit.iris.util.io.CountingDataInputStream;
-import com.volmit.iris.util.io.IO;
-import com.volmit.iris.util.scheduling.PrecisionStopwatch;
 import lombok.Getter;
-import net.jpountz.lz4.LZ4BlockInputStream;
-import net.jpountz.lz4.LZ4BlockOutputStream;
 
 import java.io.*;
-import java.nio.channels.Channels;
-import java.nio.channels.FileChannel;
-import java.nio.file.Files;
-import java.nio.file.StandardCopyOption;
-import java.nio.file.StandardOpenOption;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReferenceArray;
 
@@ -108,31 +96,6 @@ public class TectonicPlate {
                 din.skipTo(end);
                 TectonicPlate.addError();
             }
-        }
-    }
-
-    public static TectonicPlate read(int worldHeight, File file, boolean versioned) throws IOException {
-        try (FileChannel fc = FileChannel.open(file.toPath(), StandardOpenOption.READ, StandardOpenOption.WRITE, StandardOpenOption.SYNC)) {
-            fc.lock();
-
-            InputStream fin = Channels.newInputStream(fc);
-            LZ4BlockInputStream lz4 = new LZ4BlockInputStream(fin);
-            BufferedInputStream bis = new BufferedInputStream(lz4);
-            try (CountingDataInputStream din = CountingDataInputStream.wrap(bis)) {
-                return new TectonicPlate(worldHeight, din, versioned);
-            }
-        } finally {
-            if (IrisSettings.get().getGeneral().isDumpMantleOnError() && errors.get()) {
-                File dump = Iris.instance.getDataFolder("dump", file.getName() + ".bin");
-                try (FileChannel fc = FileChannel.open(file.toPath(), StandardOpenOption.READ, StandardOpenOption.WRITE, StandardOpenOption.SYNC)) {
-                    fc.lock();
-
-                    InputStream fin = Channels.newInputStream(fc);
-                    LZ4BlockInputStream lz4 = new LZ4BlockInputStream(fin);
-                    Files.copy(lz4, dump.toPath(), StandardCopyOption.REPLACE_EXISTING);
-                }
-            }
-            errors.remove();
         }
     }
 
@@ -224,18 +187,6 @@ public class TectonicPlate {
     }
 
     /**
-     * Write this tectonic plate to file
-     *
-     * @param file the file to writeNodeData it to
-     * @throws IOException shit happens
-     */
-    public void write(File file) throws IOException {
-        PrecisionStopwatch p = PrecisionStopwatch.start();
-        IO.write(file, out -> new DataOutputStream(new LZ4BlockOutputStream(out)), this::write);
-        Iris.debug("Saved Tectonic Plate " + C.DARK_GREEN + file.getName() + C.RED + " in " + Form.duration(p.getMilliseconds(), 2));
-    }
-
-    /**
      * Write this tectonic plate to a data stream
      *
      * @param dos the data output
@@ -267,5 +218,13 @@ public class TectonicPlate {
 
     public static void addError() {
         errors.set(true);
+    }
+
+    public static boolean hasError() {
+        try {
+            return errors.get();
+        } finally {
+            errors.remove();
+        }
     }
 }

--- a/core/src/main/java/com/volmit/iris/util/mantle/io/DelegateStream.java
+++ b/core/src/main/java/com/volmit/iris/util/mantle/io/DelegateStream.java
@@ -1,0 +1,123 @@
+/*
+ * Iris is a World Generator for Minecraft Bukkit Servers
+ * Copyright (c) 2022 Arcane Arts (Volmit Software)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.volmit.iris.util.mantle.io;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.channels.Channels;
+import java.nio.channels.FileChannel;
+
+public class DelegateStream {
+
+    public static InputStream read(FileChannel channel) throws IOException {
+        channel.position(0);
+        return new Input(channel);
+    }
+
+    public static OutputStream write(FileChannel channel) throws IOException {
+        channel.position(0);
+        return new Output(channel);
+    }
+
+    private static class Input extends InputStream {
+        private final InputStream delegate;
+
+        private Input(FileChannel channel) {
+            this.delegate = Channels.newInputStream(channel);
+        }
+
+        @Override
+        public int available() throws IOException {
+            return delegate.available();
+        }
+
+        @Override
+        public int read() throws IOException {
+            return delegate.read();
+        }
+
+        @Override
+        public int read(byte @NotNull [] b, int off, int len) throws IOException {
+            return delegate.read(b, off, len);
+        }
+
+        @Override
+        public byte @NotNull [] readAllBytes() throws IOException {
+            return delegate.readAllBytes();
+        }
+
+        @Override
+        public int readNBytes(byte[] b, int off, int len) throws IOException {
+            return delegate.readNBytes(b, off, len);
+        }
+
+        @Override
+        public byte @NotNull [] readNBytes(int len) throws IOException {
+            return delegate.readNBytes(len);
+        }
+
+        @Override
+        public long skip(long n) throws IOException {
+            return delegate.skip(n);
+        }
+
+        @Override
+        public void skipNBytes(long n) throws IOException {
+            delegate.skipNBytes(n);
+        }
+
+        @Override
+        public long transferTo(OutputStream out) throws IOException {
+            return delegate.transferTo(out);
+        }
+    }
+
+    private static class Output extends OutputStream {
+        private final FileChannel channel;
+        private final OutputStream delegate;
+
+        private Output(FileChannel channel) {
+            this.channel = channel;
+            this.delegate = Channels.newOutputStream(channel);
+        }
+
+        @Override
+        public void write(int b) throws IOException {
+            delegate.write(b);
+        }
+
+        @Override
+        public void write(byte @NotNull [] b, int off, int len) throws IOException {
+            delegate.write(b, off, len);
+        }
+
+        @Override
+        public void flush() throws IOException {
+            channel.truncate(channel.position());
+        }
+
+        @Override
+        public void close() throws IOException {
+            channel.force(true);
+        }
+    }
+}

--- a/core/src/main/java/com/volmit/iris/util/mantle/io/Holder.java
+++ b/core/src/main/java/com/volmit/iris/util/mantle/io/Holder.java
@@ -1,0 +1,57 @@
+/*
+ * Iris is a World Generator for Minecraft Bukkit Servers
+ * Copyright (c) 2022 Arcane Arts (Volmit Software)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.volmit.iris.util.mantle.io;
+
+import com.volmit.iris.util.io.IO;
+
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+import java.util.concurrent.Semaphore;
+
+class Holder {
+    private final FileChannel channel;
+    private final Semaphore semaphore = new Semaphore(1);
+    private volatile boolean closed;
+
+    Holder(FileChannel channel) throws IOException {
+        this.channel = channel;
+        IO.lock(channel);
+    }
+
+    SynchronizedChannel acquire() {
+        semaphore.acquireUninterruptibly();
+        if (closed) {
+            semaphore.release();
+            return null;
+        }
+
+        return new SynchronizedChannel(channel, semaphore);
+    }
+
+    void close() throws IOException {
+        semaphore.acquireUninterruptibly();
+        try {
+            if (closed) return;
+            closed = true;
+            channel.close();
+        } finally {
+            semaphore.release();
+        }
+    }
+}

--- a/core/src/main/java/com/volmit/iris/util/mantle/io/IOWorker.java
+++ b/core/src/main/java/com/volmit/iris/util/mantle/io/IOWorker.java
@@ -1,0 +1,130 @@
+/*
+ * Iris is a World Generator for Minecraft Bukkit Servers
+ * Copyright (c) 2022 Arcane Arts (Volmit Software)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.volmit.iris.util.mantle.io;
+
+import com.volmit.iris.Iris;
+import com.volmit.iris.core.IrisSettings;
+import com.volmit.iris.util.format.C;
+import com.volmit.iris.util.format.Form;
+import com.volmit.iris.util.io.CountingDataInputStream;
+import com.volmit.iris.util.mantle.TectonicPlate;
+import com.volmit.iris.util.scheduling.PrecisionStopwatch;
+import it.unimi.dsi.fastutil.objects.Object2ObjectLinkedOpenHashMap;
+import net.jpountz.lz4.LZ4BlockInputStream;
+import net.jpountz.lz4.LZ4BlockOutputStream;
+
+import java.io.*;
+import java.nio.channels.FileChannel;
+import java.nio.file.*;
+import java.util.Objects;
+import java.util.Set;
+
+public class IOWorker {
+    private static final Set<OpenOption> OPTIONS = Set.of(StandardOpenOption.READ, StandardOpenOption.WRITE, StandardOpenOption.CREATE, StandardOpenOption.SYNC);
+    private static final int MAX_CACHE_SIZE = 128;
+
+    private final Path root;
+    private final File tmp;
+    private final int worldHeight;
+
+    private final Object2ObjectLinkedOpenHashMap<String, Holder> cache = new Object2ObjectLinkedOpenHashMap<>();
+
+    public IOWorker(File root, int worldHeight) {
+        this.root = root.toPath();
+        this.tmp = new File(root, ".tmp");
+        this.worldHeight = worldHeight;
+    }
+
+    public TectonicPlate read(final String name) throws IOException {
+        PrecisionStopwatch p = PrecisionStopwatch.start();
+        try (var channel = getChannel(name)) {
+            var raw = channel.read();
+            var lz4 = new LZ4BlockInputStream(raw);
+            var buffered = new BufferedInputStream(lz4);
+            try (var in = CountingDataInputStream.wrap(buffered)) {
+                return new TectonicPlate(worldHeight, in, name.startsWith("pv."));
+            } finally {
+                if (TectonicPlate.hasError() && IrisSettings.get().getGeneral().isDumpMantleOnError()) {
+                    File dump = Iris.instance.getDataFolder("dump", name + ".bin");
+                    Files.copy(new LZ4BlockInputStream(channel.read()), dump.toPath(), StandardCopyOption.REPLACE_EXISTING);
+                } else {
+                    Iris.debug("Read Tectonic Plate " + C.DARK_GREEN + name + C.RED + " in " + Form.duration(p.getMilliseconds(), 2));
+                }
+            }
+        }
+    }
+
+    public void write(final String name, final TectonicPlate plate) throws IOException {
+        PrecisionStopwatch p = PrecisionStopwatch.start();
+        try (var channel = getChannel(name)) {
+            tmp.mkdirs();
+            File file = File.createTempFile("iris", ".bin", tmp);
+            try {
+                try (var tmp = new DataOutputStream(new LZ4BlockOutputStream(new FileOutputStream(file)))) {
+                    plate.write(tmp);
+                }
+
+                try (var out = channel.write()) {
+                    Files.copy(file.toPath(), out);
+                    out.flush();
+                }
+            } finally {
+                file.delete();
+            }
+        }
+        Iris.debug("Saved Tectonic Plate " + C.DARK_GREEN + name + C.RED + " in " + Form.duration(p.getMilliseconds(), 2));
+    }
+
+    public void close() throws IOException {
+        synchronized (cache) {
+            for (Holder h : cache.values()) {
+                h.close();
+            }
+
+            cache.clear();
+        }
+    }
+
+    private SynchronizedChannel getChannel(final String name) throws IOException {
+        PrecisionStopwatch p = PrecisionStopwatch.start();
+        try {
+            synchronized (cache) {
+                Holder holder = cache.getAndMoveToFirst(name);
+                if (holder != null) {
+                    var channel = holder.acquire();
+                    if (channel != null) {
+                        return channel;
+                    }
+                }
+
+                if (cache.size() >= MAX_CACHE_SIZE) {
+                    var last = cache.removeLast();
+                    last.close();
+                }
+
+
+                holder = new Holder(FileChannel.open(root.resolve(name), OPTIONS));
+                cache.putAndMoveToFirst(name, holder);
+                return Objects.requireNonNull(holder.acquire());
+            }
+        } finally {
+            Iris.debug("Acquired Channel for " + C.DARK_GREEN + name + C.RED + " in " + Form.duration(p.getMilliseconds(), 2));
+        }
+    }
+}

--- a/core/src/main/java/com/volmit/iris/util/mantle/io/SynchronizedChannel.java
+++ b/core/src/main/java/com/volmit/iris/util/mantle/io/SynchronizedChannel.java
@@ -1,0 +1,54 @@
+/*
+ * Iris is a World Generator for Minecraft Bukkit Servers
+ * Copyright (c) 2022 Arcane Arts (Volmit Software)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.volmit.iris.util.mantle.io;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.channels.FileChannel;
+import java.util.concurrent.Semaphore;
+
+public class SynchronizedChannel implements Closeable {
+    private final FileChannel channel;
+    private final Semaphore lock;
+    private transient boolean closed;
+
+    SynchronizedChannel(FileChannel channel, Semaphore lock) {
+        this.channel = channel;
+        this.lock = lock;
+    }
+
+    public InputStream read() throws IOException {
+        if (closed) throw new IOException("Channel is closed!");
+        return DelegateStream.read(channel);
+    }
+
+    public OutputStream write() throws IOException {
+        if (closed) throw new IOException("Channel is closed!");
+        return DelegateStream.write(channel);
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (closed) return;
+        closed = true;
+        lock.release();
+    }
+}

--- a/core/src/main/java/com/volmit/iris/util/matter/IrisMatter.java
+++ b/core/src/main/java/com/volmit/iris/util/matter/IrisMatter.java
@@ -25,6 +25,8 @@ import com.volmit.iris.util.json.JSONObject;
 import com.volmit.iris.util.plugin.VolmitSender;
 import lombok.Getter;
 
+import java.util.Objects;
+
 public class IrisMatter extends IrisRegistrant implements Matter {
     protected static final KMap<Class<?>, MatterSlice<?>> slicers = buildSlicers();
 
@@ -63,6 +65,12 @@ public class IrisMatter extends IrisRegistrant implements Matter {
         }
 
         return c;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> MatterSlice<T> slice(Class<?> c) {
+        return (MatterSlice<T>) sliceMap.computeIfAbsent(c, $ -> Objects.requireNonNull(createSlice(c, this), "Bad slice " + c.getCanonicalName()));
     }
 
     @Override

--- a/core/src/main/java/com/volmit/iris/util/matter/Matter.java
+++ b/core/src/main/java/com/volmit/iris/util/matter/Matter.java
@@ -99,10 +99,9 @@ public interface Matter {
     }
 
     static Matter read(File f) throws IOException {
-        FileInputStream in = new FileInputStream(f);
-        Matter m = read(in);
-        in.close();
-        return m;
+        try (var in = new FileInputStream(f)) {
+            return read(in);
+        }
     }
 
     static Matter read(InputStream in) throws IOException {
@@ -164,6 +163,10 @@ public interface Matter {
                     TectonicPlate.addError();
                 }
                 din.skipTo(end);
+            }
+
+            if (din.count() != start + size) {
+                throw new IOException("Matter slice read size mismatch!");
             }
         }
 

--- a/core/src/main/java/com/volmit/iris/util/matter/Matter.java
+++ b/core/src/main/java/com/volmit/iris/util/matter/Matter.java
@@ -141,6 +141,7 @@ public interface Matter {
             long size = din.readInt();
             if (size == 0) continue;
             long start = din.count();
+            long end = start + size;
 
             Iris.addPanic("read.matter.slice", i + "");
             try {
@@ -150,9 +151,9 @@ public interface Matter {
                 Class<?> type = Class.forName(cn);
                 MatterSlice<?> slice = matter.createSlice(type, matter);
                 slice.read(din);
+                if (din.count() < end) throw new IOException("Matter slice read size mismatch!");
                 matter.putSlice(type, slice);
             } catch (Throwable e) {
-                long end = start + size;
                 if (!(e instanceof ClassNotFoundException)) {
                     Iris.error("Failed to read matter slice, skipping it.");
                     Iris.addPanic("read.byte.range", start + " " + end);
@@ -165,7 +166,7 @@ public interface Matter {
                 din.skipTo(end);
             }
 
-            if (din.count() != start + size) {
+            if (din.count() != end) {
                 throw new IOException("Matter slice read size mismatch!");
             }
         }

--- a/core/src/main/java/com/volmit/iris/util/parallel/HyperLock.java
+++ b/core/src/main/java/com/volmit/iris/util/parallel/HyperLock.java
@@ -22,6 +22,7 @@ import com.googlecode.concurrentlinkedhashmap.ConcurrentLinkedHashMap;
 import com.volmit.iris.Iris;
 import com.volmit.iris.engine.data.cache.Cache;
 import com.volmit.iris.util.function.NastyRunnable;
+import com.volmit.iris.util.function.NastySupplier;
 import com.volmit.iris.util.io.IORunnable;
 
 import java.io.IOException;
@@ -105,6 +106,15 @@ public class HyperLock {
         T t = r.get();
         unlock(x, z);
         return t;
+    }
+
+    public <T> T withNastyResult(int x, int z, NastySupplier<T> r) throws Throwable {
+        lock(x, z);
+        try {
+            return r.get();
+        } finally {
+            unlock(x, z);
+        }
     }
 
     public boolean tryLock(int x, int z) {

--- a/core/src/main/java/com/volmit/iris/util/parallel/StreamUtils.java
+++ b/core/src/main/java/com/volmit/iris/util/parallel/StreamUtils.java
@@ -1,0 +1,34 @@
+package com.volmit.iris.util.parallel;
+
+import com.volmit.iris.util.math.Position2;
+import lombok.SneakyThrows;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+public class StreamUtils {
+
+    public static Stream<Position2> streamRadius(int x, int z, int radius) {
+        return streamRadius(x, z, radius, radius);
+    }
+
+    public static Stream<Position2> streamRadius(int x, int z, int radiusX, int radiusZ) {
+        return IntStream.rangeClosed(-radiusX, radiusX)
+                .mapToObj(xx -> IntStream.rangeClosed(-radiusZ, radiusZ)
+                        .mapToObj(zz -> new Position2(x + xx, z + zz)))
+                .flatMap(Function.identity());
+    }
+
+    public static <T, M> void forEach(Stream<T> stream, Function<T, Stream<M>> mapper, Consumer<M> consumer, @Nullable MultiBurst burst) {
+        forEach(stream.flatMap(mapper), consumer, burst);
+    }
+
+    @SneakyThrows
+    public static <T> void forEach(Stream<T> stream, Consumer<T> task, @Nullable MultiBurst burst) {
+        if (burst == null) stream.forEach(task);
+        else burst.submit(() -> stream.parallel().forEach(task)).get();
+    }
+}


### PR DESCRIPTION
Fixes: 
- potential issues in the CountingDataInputStream
- incorrect data bit resizing causing mantle corruption
- ItemsAdder namespaces not reloading properly
- not waiting for the chunk updater to finish
- shutdown hook not working when stopping with exit signal
- skipping stronghold in mantle radius calc
- few unsafe mantle opterations
- random null pointer in the resource loader
- structures not being placed properly

Changes:
- centralize mantle file channels to prevent concurrent access
- add size check to prevent further corruption in case of read offset
- change the trimming cycle to make sure one step happens per second
- general optimization for the generator and updater