### PR TITLE
add auxilor maven to fix build error.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -198,6 +198,7 @@ allprojects {
         mavenCentral()
         maven("https://repo.papermc.io/repository/maven-public/")
         maven("https://repo.codemc.org/repository/maven-public/")
+        maven("https://repo.auxilor.io/repository/maven-public/")
 
         maven("https://jitpack.io") // EcoItems, score
         maven("https://repo.nexomc.com/releases/") // nexo


### PR DESCRIPTION
Fix the following build error:

* What went wrong: Execution failed for task ':core:compileKotlin'.
> Could not resolve all files for configuration ':core:compileClasspath'.
   > Could not find com.willfp:EcoItems:5.63.1.
     Searched in the following locations:
       - https://repo.maven.apache.org/maven2/com/willfp/EcoItems/5.63.1/EcoItems-5.63.1.pom
       - https://repo.papermc.io/repository/maven-public/com/willfp/EcoItems/5.63.1/EcoItems-5.63.1.pom - https://repo.codemc.org/repository/maven-public/com/willfp/EcoItems/5.63.1/EcoItems-5.63.1.pom - https://jitpack.io/com/willfp/EcoItems/5.63.1/EcoItems-5.63.1.pom - https://repo.nexomc.com/releases/com/willfp/EcoItems/5.63.1/EcoItems-5.63.1.pom - https://maven.devs.beer/com/willfp/EcoItems/5.63.1/EcoItems-5.63.1.pom - https://repo.extendedclip.com/releases/com/willfp/EcoItems/5.63.1/EcoItems-5.63.1.pom - https://mvn.lumine.io/repository/maven-public/com/willfp/EcoItems/5.63.1/EcoItems-5.63.1.pom - https://nexus.phoenixdevt.fr/repository/maven-public/com/willfp/EcoItems/5.63.1/EcoItems-5.63.1.pom - https://repo.onarandombox.com/content/groups/public/com/willfp/EcoItems/5.63.1/EcoItems-5.63.1.pom Required by: project :core

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.
> Get more help at https://help.gradle.org.

Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/8.14.2/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.

BUILD FAILED in 51s
19 actionable tasks: 17 executed, 2 up-to-date